### PR TITLE
Changes we've made to tlsdate(1) locally for Chromium OS

### DIFF
--- a/tlsdate-helper.c
+++ b/tlsdate-helper.c
@@ -124,6 +124,8 @@ static const char *port;
 
 static const char *protocol;
 
+static const char *certdir;
+
 /** helper function to print message and die */
 static void
 die(const char *fmt, ...)
@@ -189,9 +191,7 @@ run_ssl (uint32_t *time_map)
 
   if (ca_racket)
   {
-    // For google specifically:
-    // SSL_CTX_load_verify_locations(ctx, "/etc/ssl/certs/Equifax_Secure_CA.pem", NULL);
-    if (1 != SSL_CTX_load_verify_locations(ctx, NULL, "/etc/ssl/certs/"))
+    if (1 != SSL_CTX_load_verify_locations(ctx, NULL, certdir))
       fprintf(stderr, "SSL_CTX_load_verify_locations failed\n");
   }
 
@@ -306,11 +306,12 @@ main(int argc, char **argv)
   long long rt_time_ms;
   uint32_t server_time_s;
 
-  if (argc != 6)
+  if (argc != 7)
     return 1;
   host = argv[1];
   port = argv[2];
   protocol = argv[3];
+  certdir = argv[6];
   ca_racket = (0 != strcmp ("unchecked", argv[4]));
   verbose = (0 != strcmp ("quiet", argv[5]));
 

--- a/tlsdate.c
+++ b/tlsdate.c
@@ -84,6 +84,7 @@ know:
 #define DEFAULT_HOST "www.ptb.de"
 #define DEFAULT_PORT "443"
 #define DEFAULT_PROTOCOL "tlsv1"
+#define DEFAULT_CERTDIR "/etc/ssl/certs"
 
 /** Return the proper commandline switches when the user needs information. */
 static void
@@ -95,6 +96,7 @@ usage(void)
           " [-H|--host] [hostname|ip]\n"
           " [-p|--port] [port number]\n"
           " [-P|--protocol] [sslv23|sslv3|tlsv1]\n"
+          " [-C|--certdir] [dirname]\n"
           " [-v|--verbose]\n");
 }
 
@@ -107,10 +109,12 @@ main(int argc, char **argv)
   const char *host;
   const char *port;
   const char *protocol;
+  const char *certdir;
 
   host = DEFAULT_HOST;
   port = DEFAULT_PORT;
   protocol = DEFAULT_PROTOCOL;
+  certdir = DEFAULT_CERTDIR;
   verbose = 0;
   ca_racket = 1;
 
@@ -126,10 +130,11 @@ main(int argc, char **argv)
         {"host", 0, 0, 'H'},
         {"port", 0, 0, 'p'},
         {"protocol", 0, 0, 'P'},
+        {"certdir", 0, 0, 'C'},
         {0, 0, 0, 0}
       };
 
-    c = getopt_long(argc, argv, "vshH:p:P:",
+    c = getopt_long(argc, argv, "vshH:p:P:C:",
                     long_options, &option_index);
     if (c == -1)
       break;
@@ -141,6 +146,7 @@ main(int argc, char **argv)
       case 'H': host = optarg; break;
       case 'p': port = optarg; break;
       case 'P': protocol = optarg; break;
+      case 'C': certdir = optarg; break;
       case '?': break;
       default : fprintf(stderr, "Unknown option!\n"); usage(); exit(1);
     }
@@ -165,6 +171,7 @@ main(int argc, char **argv)
     protocol,
     (ca_racket ? "racket" : "unchecked"),
     (verbose ? "verbose" : "quiet"),
+    certdir,
     NULL);
   perror("Failed to run tlsdate-helper");
   return 1;


### PR DESCRIPTION
1. Let the build env set RECENT_COMPILE_DATE, UNPRIV_USER, and UNPRIV_GROUP
2. Fix a typo in usage
3. Support -C/--certdir to specify where to find trusted SSL certs

We use #3 with a directory containing only the root CA we know signs our server's TLS cert to mitigate the CA-compromise problem.
