### PR TITLE
Small fixes

### DIFF
--- a/tlsdate-helper.c
+++ b/tlsdate-helper.c
@@ -215,10 +215,9 @@ run_ssl (uint32_t *time_map)
     die ("SSL handshake failed\n");
   // Verify the peer certificate against the CA certs on the local system
   if (ca_racket) {
-    X509 *x509;
     long ssl_verify_result;
 
-    if (NULL == (x509 = SSL_get_peer_certificate(ssl)) )
+    if (NULL == SSL_get_peer_certificate(ssl))
       die ("Getting SSL certificate failed\n");
 
     // In theory, we verify that the cert is valid


### PR DESCRIPTION
I found the printing out the difference on the error message for being unable to set clock useful in debugging (who needs verbose anyway :)

Also two variables that were set but not used (as shown by "cppcheck --enable=all -I. *c" )
