### PR TITLE
Fix ignored const qualifier for X509V3_EXT_get

### DIFF
--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -273,7 +273,7 @@ check_san (SSL *ssl, const char *hostname)
 
         STACK_OF(CONF_VALUE) *val;
         CONF_VALUE *nval;
-        X509V3_EXT_METHOD *method;
+        const X509V3_EXT_METHOD *method;
 
         if (!(method = X509V3_EXT_get(ext)))
         {


### PR DESCRIPTION
Signed-off-by: David Goulet dgoulet@ev0ke.net
