### PR TITLE
 Add libcompat with generic clocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .deps/
+.libs/
 autom4te.cache/
 Makefile
 Makefile.in
@@ -10,6 +11,7 @@ config.sub
 configure
 depcomp
 install-sh
+libtool
 missing
 stamp-h1
 config/

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@ AM_CONFIG_HEADER([config/tlsdate-config.h])
 AM_INIT_AUTOMAKE([tlsdate], [0.0.1])
 AC_CANONICAL_HOST
 AH_TOP([#define _GNU_SOURCE  1])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+LT_INIT
 
 # Debug and hardening flags all in one shot
 CFLAGS=" -g -O1 -Wall -fno-strict-aliasing "
@@ -44,4 +47,4 @@ AC_CHECK_HEADERS(
 
 AC_CHECK_FUNCS([setresuid gettimeofday])
 
-AC_OUTPUT(Makefile src/Makefile)
+AC_OUTPUT(Makefile src/Makefile src/compat/Makefile)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,13 @@
+SUBDIRS = compat
+
 AUTOMAKE_OPTIONS = foreign 1.7
 
 # Our main program
 bin_PROGRAMS = tlsdate tlsdate-helper
 tlsdate_SOURCES = tlsdate.c
 tlsdate_helper_SOURCES = tlsdate-helper.c
-tlsdate_helper_LDADD = -lssl -lcrypto
+tlsdate_helper_LDADD = -lssl -lcrypto -lrt \
+                       $(top_builddir)/src/compat/libcompat.la
 
 # We're not shipping headers
 noinst_HEADERS = tlsdate.h

--- a/src/compat/Makefile.am
+++ b/src/compat/Makefile.am
@@ -1,0 +1,5 @@
+AM_CPPFLAGS =
+
+lib_LTLIBRARIES = libcompat.la
+
+libcompat_la_SOURCES = clock-linux.c clock.h

--- a/src/compat/clock-linux.c
+++ b/src/compat/clock-linux.c
@@ -1,0 +1,57 @@
+/* Copyright (c) 2012, David Goulet <dgoulet@ev0ke.net>
+ *                     Jacob Appelbaum
+ * Copyright (c) 2012, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+  * \file clock.c
+  * \brief Contains clock primitives for Linux OS
+  **/
+
+#include <assert.h>
+
+#include "clock.h"
+
+/**
+ * Get current real time value and store it into time.
+ *
+ * @param time where the current time is stored
+ * @return clock_gettime syscall return value
+ */
+int clock_get_real_time_linux(struct tlsdate_time *time)
+{
+  /* Safety net */
+  assert(time);
+
+  return clock_gettime(CLOCK_REALTIME, &time->tp);
+}
+
+/**
+ * Set current real time clock using time.
+ *
+ * @param time where the current time to set is stored
+ * @return clock_settime syscall return value
+ */
+int clock_set_real_time_linux(const struct tlsdate_time *time)
+{
+  /* Safety net */
+  assert(time);
+
+  return clock_settime(CLOCK_REALTIME, &time->tp);
+}
+
+/**
+ * Init a tlsdate_time structure.
+ *
+ * @param sec is the seconds
+ * @param nsec is the nanoseconds
+ */
+void clock_init_time_linux(struct tlsdate_time *time, time_t sec,
+                           long nsec)
+{
+  /* Safety net */
+  assert(time);
+
+  time->tp.tv_sec = sec;
+  time->tp.tv_nsec = nsec;
+}

--- a/src/compat/clock.h
+++ b/src/compat/clock.h
@@ -1,0 +1,59 @@
+/* Copyright (c) 2012, David Goulet <dgoulet@ev0ke.net>
+ *                     Jacob Appelbaum
+ * Copyright (c) 2012, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+  * \file clock.h
+  * \brief Header file for the clock primitives.
+  **/
+
+#ifdef __linux__
+
+#include <time.h>
+
+struct tlsdate_time {
+    struct timespec tp;
+};
+
+extern int clock_get_real_time_linux(struct tlsdate_time *time);
+#define clock_get_real_time(time) clock_get_real_time_linux(time)
+
+extern int clock_set_real_time_linux(const struct tlsdate_time *time);
+#define clock_set_real_time(time) clock_set_real_time_linux(time)
+
+extern void clock_init_time_linux(struct tlsdate_time *time, time_t sec,
+                                  long nsec);
+#define clock_init_time(time, sec, nsec) \
+        clock_init_time_linux(time, sec, nsec)
+
+/* Helper macros to access time values */
+#define CLOCK_SEC(time)  ((time)->tp.tv_sec)
+#define CLOCK_MSEC(time) ((time)->tp.tv_nsec / 1000000)
+#define CLOCK_USEC(time) ((time)->tp.tv_nsec / 1000)
+#define CLOCK_NSEC(time) ((time)->tp.tv_nsec)
+
+#elif _WIN32
+
+struct tlsdate_time {
+    /* TODO: Fix Windows support */
+};
+
+extern int clock_get_real_time_win(struct tlsdate_time *time);
+#define clock_get_real_time(time) clock_get_real_time_win(time)
+
+extern int clock_set_real_time_win(const struct tlsdate_time *time);
+#define clock_set_real_time(time) clock_set_real_time_win(time)
+
+extern void clock_init_time_win(struct tlsdate_time *time, time_t sec,
+                                long nsec);
+#define clock_init_time(time, sec, nsec) \
+        clock_init_time_win(time, sec, nsec)
+
+/* Helper macros to access time values. TODO: Complete them */
+#define CLOCK_SEC(time)
+#define CLOCK_MSEC(time)
+#define CLOCK_USEC(time)
+#define CLOCK_NSEC(time)
+
+#endif /* __linux__ _WIN32 */


### PR DESCRIPTION
First, this patch changes gettimeofday and settimeofday function call by
clock_gettime and clock_settime using the CLOCK_REALTIME id. The reason
for that is for POSIX compliance and portability.

Thinking ahead for a possible Windows port, this patch also introduce a
basic compatibility layer where generic function can be used which
points to the right OS code. A libcompat is available which for now only
provide an interface for clocks.

Refer to src/compat/clock.h for the possible calls and options. The
tlsdate-helper was refactored to use this libcompat and new clock calls.

Also silent compilation output so warnings and errors can easily be seen
during compile time.

Signed-off-by: David Goulet dgoulet@ev0ke.net
