### PR TITLE
Fixed changelog, wrap-and-sort control file, removed unneeded dependenci...

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
 tlsdate (0.0.4-1) unstable; urgency=low
 
-  * New upstream version
-  * Merge in all git fixes after 0.0.4 to fix various lintian issues
+  * Initial release (Closes: #681000)
+  * New upstream version.
+  * Merge in all git fixes after 0.0.4 to fix various lintian issues.
 
  -- Jacob Appelbaum <jacob@appelbaum.net>  Wed, 07 Nov 2012 21:36:15 -0800
 
@@ -20,6 +21,6 @@ tlsdate (0.0.2-1) unstable; urgency=low
 
 tlsdate (0.0.1-1) unstable; urgency=low
 
-  * Initial release (Closes: #681000).
+  * Initial release.
 
  -- Jacob Appelbaum <jacob@appelbaum.net>  Mon, 09 Jul 2012 21:04:36 +0200

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,17 @@ Source: tlsdate
 Section: net
 Priority: extra
 Maintainer: Jacob Appelbaum <jacob@appelbaum.net>
-Build-Depends: debhelper (>= 7.0.50~), autotools-dev, libssl-dev, dh-apparmor, dpkg (>= 1.16.1.1), hardening-includes
+Build-Depends: autotools-dev,
+               debhelper (>= 7.0.50~),
+               dh-apparmor,
+               hardening-wrapper,
+               libssl-dev
 Standards-Version: 3.9.3
 Homepage: https://www.github.com/ioerror/tlsdate/
-Vcs-Git: git://github.com/ioerror/tlsdate.git
 
 Package: tlsdate
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: secure parasitic rdate replacement
  tlsdate sets the local clock by securely connecting with TLS to remote
  servers and extracting the remote time out of the secure handshake. Unlike

--- a/debian/rules
+++ b/debian/rules
@@ -1,38 +1,18 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-# Per http://wiki.debian.org/Hardening#hardening-wrapper
-# we add the following:
+
+# See: http://wiki.debian.org/Hardening#hardening-wrapper
 export DEB_BUILD_HARDENING=1
 
-# Per http://wiki.debian.org/Hardening#hardening-includes
-# we add the following:
-include /usr/share/hardening-includes/hardening.make
-
-CFLAGS=$(shell dpkg-buildflags --get CFLAGS)
-LDFLAGS=$(shell dpkg-buildflags --get LDFLAGS)
-CFLAGS+=$(HARDENING_CFLAGS)
-LDFLAGS+=$(HARDENING_LDFLAGS)
-
 %:
-	dh $@ 
+	dh $@
 
 override_dh_install:
 	dh_install
 	# Remove .la file
 	rm -f debian/tlsdate/usr/lib/libtlsdate_compat.la
+	
 	cp apparmor-profile debian/tlsdate/etc/apparmor.d/usr.bin.tlsdate
 	dh_apparmor --profile-name=usr.bin.tlsdate -ptlsdate
-
-# Ubuntu does the following for apparmor
-#binary-install/tlsdate::
-#	cp apparmor-profile debian/tlsdate/etc/apparmor.d/usr.bin.tlsdate
-#	dh_apparmor --profile-name=usr.bin.tlsdate -ptlsdate

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -3,9 +3,11 @@ tlsdate binary: package-name-doesnt-match-sonames *
 tlsdate binary: non-dev-pkg-with-shlib-symlink usr/lib/libtlsdate_compat.so.0.0.0 usr/lib/libtlsdate_compat.so
 tlsdate binary: non-dev-pkg-with-shlib-symlink *
 tlsdate binary: no-symbols-control-file *
+#tlsdate contains apparmor profile file which doesn't link to OpenSSL.
 tlsdate binary: possible-gpl-code-linked-with-openssl *
 tlsdate source: package-name-doesnt-match-sonames libtlsdate-compat0
 tlsdate source: non-dev-pkg-with-shlib-symlink usr/lib/libtlsdate_compat.so.0.0.0 usr/lib/libtlsdate_compat.so
 tlsdate source: non-dev-pkg-with-shlib-symlink *
 tlsdate source: no-symbols-control-file *
+#tlsdate contains apparmor profile file which doesn't link to OpenSSL.
 tlsdate source: possible-gpl-code-linked-with-openssl *


### PR DESCRIPTION
debian/changelog: fixed for Debian upload.
debian/control: wrap-and-sort, removed unneeded dependencies, don't point to upstream git location.
debian/rules: only one hardening support needed! and cleanups.
debian/source/lintian-overrides: added note about openssl overrides.
