### PR TITLE
Configure Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-install: ./autogen.sh && ./configure && make && make test
+language: c
+before_script: ./autogen.sh
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
Lots of warnings compiling using clang and a few using gcc, but tests pass.

Clang: https://travis-ci.org/mikepb/tlsdate/jobs/3176003
GCC: https://travis-ci.org/mikepb/tlsdate/jobs/3176004
