### PR TITLE
[tlsdate] fix certificate time compensation

### DIFF
--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -210,7 +210,7 @@ void
 openssl_time_callback (const SSL* ssl, int where, int ret)
 {
   if (where == SSL_CB_CONNECT_LOOP &&
-      (ssl->state == SSL3_ST_CR_CERT_A || ssl->state == SSL3_ST_CR_CERT_B))
+      (ssl->state == SSL3_ST_CR_SRVR_HELLO_A || ssl->state == SSL3_ST_CR_SRVR_HELLO_B))
   {
     // XXX TODO: If we want to trust the remote system for time,
     // can we just read that time out of the remote system and if the
@@ -231,7 +231,8 @@ openssl_time_callback (const SSL* ssl, int where, int ret)
       verb("V: remote peer provided: %d, preferred over compile time: %d\n",
             ntohl(server_time), compiled_time);
       verb("V: freezing time with X509_VERIFY_PARAM_set_time\n");
-      X509_VERIFY_PARAM_set_time(ssl->ctx->param, (time_t) ntohl(server_time));
+      X509_VERIFY_PARAM_set_time(ssl->ctx->cert_store->param,
+                                 (time_t) ntohl(server_time) + 86400);
     } else {
       die("V: the remote server is a false ticker! server: %d compile: %d\n",
            ntohl(server_time), compiled_time);


### PR DESCRIPTION
Fix the code that compensates for certificates whose time is in the future, to
prevent a situation where it's impossible to fetch a new time because our
current time is too old. There are two bugs:
1. We try to use the server's time too late, after we've already done cert
   validation; we need to do it earlier (during the server hello).
2. We set the time on the wrong context - we need to set the time on the cert
   store instead of just the context object, since when OpenSSL is setting up to
   verify the cert, it copies the cert store's params instead of the SSL context's
   params.

BUG=chromium-os:36738
TEST=adhoc
date -s '2012-01-01 00:00:00' && tlsdate -l -v -H clients3.google.com -p 443

Change-Id: Ie1b11a2e0ecdc2196b729f6d5483b53c54a1933d
Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
(cherry picked from commit 87ee9c2c23eff1816adc069c3b41f84933779643)
