### PR TITLE
[tlsdate] don't install libcompat.la

### DIFF
--- a/src/compat/include.am
+++ b/src/compat/include.am
@@ -1,6 +1,6 @@
 # vim:ft=automake
 
-lib_LTLIBRARIES+= src/compat/libtlsdate_compat.la
+noinst_LTLIBRARIES+= src/compat/libtlsdate_compat.la
 
 src_compat_libtlsdate_compat_la_SOURCES = src/compat/clock-linux.c
 src_compat_libtlsdate_compat_la_CFLAGS = -DBUILDING_TLSDATE


### PR DESCRIPTION
This line, for reasons I do not understand, causes automake to leave a libtool
shell script in place of the tlsdate-helper binary, which attempts to invoke the
platform's compiler (!); this breaks cross-compilation.

BUG=none
TEST=adhoc
/usr/sbin/tlsdate-helper doesn't complain about missing $PLATFORM-gnu-gcc or
similar.

TODO: why? find an automake expert

Change-Id: I32ae267c701a1113bed22ce2a5d784f77df9492a
Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
