### PR TITLE
Clear netlink receive queue after reading to avoid an overflow

### DIFF
--- a/src/routeup.c
+++ b/src/routeup.c
@@ -11,6 +11,8 @@
 
 #include <asm/types.h>
 #include <sys/socket.h>   /* needed for linux/if.h for struct sockaddr */
+#include <errno.h>
+#include <fcntl.h>
 #include <linux/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -48,6 +50,12 @@ routeup_setup (struct routeup *rtc)
   if (bind (rtc->netlinkfd, (struct sockaddr *) &sa, sizeof (sa)) < 0)
     {
       perror ("netlink bind() failed");
+      close (rtc->netlinkfd);
+      return 1;
+    }
+  if (fcntl (rtc->netlinkfd, F_SETFL, O_NONBLOCK) < 0)
+    {
+      perror ("netlink fcntl(O_NONBLOCK) failed");
       close (rtc->netlinkfd);
       return 1;
     }
@@ -96,6 +104,13 @@ routeup_once (struct routeup *rtc, unsigned int timeout)
       break;
     if (nh->nlmsg_type != RTM_NEWROUTE)
       continue;
+    /*
+     * Clear out the socket so we don't keep old messages
+     * queued up and eventually overflow the receive buffer.
+     */
+    while (read (rtc->netlinkfd, buf, sizeof(buf)) > 0)
+      /* loop through receive queue */;
+    if (errno != EAGAIN) return -1;
     return 0;
   }
     }


### PR DESCRIPTION
tlsdated only reads its NETLINK_ROUTE socket until finding the first
RTM_NEWROUTE message. After that, it will sleep at least
wait_between_tries seconds before reading the socket again.

On subnets with many hosts (such as a large public WiFi), the kernel
can generate a _lot_ of route updates for IPv6 solicited-node multicast
addresses. If tlsdated does not read them fast enough, they will queue
up and eventually overflow the socket receive buffer. This results in an
ENOBUFS error which will cause the process to terminate itself.

This patch ensures that tlsdated always reads all available packets in
its netlink receive queue before proceeding. As we only care if there
have been any route updates at all during one read, the additional
packets can simply be discarded. This also makes sure that they will not
be read at a later date (and misinterpreted as current packets at a time
when there are no more route updates).

BUG=chromium-os:36426
TEST=Join GoogleGuest or a similar large network. strace tlsdated and
observe how it will not die despite occasional large bursts of netlink
packets.

Change-Id: Idbaf4be6d888c45256220055242b6f9b4d77bc93
Signed-off-by: Julius Werner jwerner@chromium.org
Reviewed-on: https://gerrit.chromium.org/gerrit/38173
Reviewed-by: Elly Jones ellyjones@chromium.org

Conflicts:
    src/routeup.c
