### PR TITLE
Fix warnings.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -11,7 +11,9 @@
 #include <pwd.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/types.h>
 #include <syslog.h>
+#include <unistd.h>
 
 #include "src/util.h"
 


### PR DESCRIPTION
Two sets of warnings: one about setresgid/setresuid prototypes in util.c, the
other about use of alloca() disabling stack protection in the unit tests.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
(cherry picked from commit 39c89473304efea4f4e25a08bcf21a301e0d2213)
