### PR TITLE
tlsdated: add jitter (-j).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
   Add support for lcov/gcov at build time
     see ./configure --enable-code-coverage-checks and make lcov
   Don't hardfail if DEFAULT_RTC_DEVICE cannot be opened, even if desired
+  Support -j to add jitter to tlsdated time checks.
 0.0.4 Wed 7 Nov, 2012
   Fixup CHANGELOG and properly tag
     Version Numbers Are Free! Hooray!

--- a/TODO
+++ b/TODO
@@ -38,7 +38,6 @@ Here is a nice list of things to do to improve tlsdate:
 41) Port to Mac OS X 10.8.2
      This work has started in a private branch
 42) Unit-test everything
-43) Random jitter on when we do time fetches
 44) Exponential backoff
 45) Drop root from tlsdated
 46) Support multiple fetch hosts

--- a/man/tlsdated.1
+++ b/man/tlsdated.1
@@ -42,6 +42,8 @@ run at most every n seconds in steady state
 don't load disk timestamps 
 .IP "\-s"
 don't save disk timestamp
+.IP "\-j [n]"
+add up to n seconds of jitter to steady-state fetches
 .IP "\-v"
 be verbose
 .IP "\-h"

--- a/src/include.am
+++ b/src/include.am
@@ -22,6 +22,7 @@ src_tlsdate_helper_SOURCES+= src/proxy-bio.c
 src_tlsdate_helper_SOURCES+= src/util.c
 
 src_tlsdated_CFLAGS = -DTLSDATED_MAIN
+src_tlsdated_LDADD = -lcrypto
 src_tlsdated_SOURCES = src/routeup.c
 src_tlsdated_SOURCES+= src/tlsdated.c
 src_tlsdated_SOURCES+= src/util.c
@@ -30,6 +31,7 @@ src_tlsdate_dbus_announce_CFLAGS = @DBUS_CFLAGS@
 src_tlsdate_dbus_announce_LDADD = @DBUS_LIBS@
 src_tlsdate_dbus_announce_SOURCES = src/tlsdate-dbus-announce.c
 
+src_tlsdated_unittest_LDADD = -lcrypto
 src_tlsdated_unittest_SOURCES = src/routeup.c
 src_tlsdated_unittest_SOURCES+= src/tlsdated-unittest.c
 src_tlsdated_unittest_SOURCES+= src/util.c

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -56,6 +56,7 @@ static const char kTestHost[] = { TEST_HOST, 0 };
 int is_sane_time (time_t ts);
 int load_disk_timestamp (const char *path, time_t * t);
 void save_disk_timestamp (const char *path, time_t t);
+int add_jitter (int base, int jitter);
 int tlsdate (char *argv[], char *envp[], int tries, int wait_between_tries);
 
 /** This is where we store parsed commandline options. */

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -120,4 +120,20 @@ TEST(tlsdate_tests) {
   EXPECT_EQ(0, tlsdate(args, environ, 2, 5));
 }
 
+TEST(jitter) {
+  int i = 0;
+  int r;
+  const int kBase = 100;
+  const int kJitter = 25;
+  int nonequal = 0;
+  for (i = 0; i < 1000; i++) {
+    r = add_jitter(kBase, kJitter);
+    EXPECT_GE(r, kBase - kJitter);
+    EXPECT_LE(r, kBase + kJitter);
+    if (r != kBase)
+      nonequal++;
+  }
+  EXPECT_NE(nonequal, 0);
+}
+
 TEST_HARNESS_MAIN

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <linux/rtc.h>
+#include <openssl/rand.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -242,6 +243,17 @@ sync_and_save (int hwclock_fd, int should_sync, int should_save)
     }
 }
 
+int
+add_jitter (int base, int jitter)
+{
+  int n = 0;
+  if (!jitter)
+    return base;
+  if (RAND_bytes((unsigned char *)&n, sizeof(n)) != 1)
+    fatal ("RAND_bytes() failed");
+  return base + (abs(n) % (2 * jitter)) - jitter;
+}
+
 #ifdef TLSDATED_MAIN
 #ifdef HAVE_DBUS
 void
@@ -291,6 +303,7 @@ usage (const char *progn)
   printf ("  -c <path> set the cache directory\n");
   printf ("  -a <n>    run at most every n seconds in steady state\n");
   printf ("  -m <n>    run at most once every n seconds in steady state\n");
+  printf ("  -j <n>    add up to n seconds jitter to steady state checks\n");
   printf ("  -l        don't load disk timestamps\n");
   printf ("  -s        don't save disk timestamps\n");
   printf ("  -v        be verbose\n");
@@ -319,10 +332,12 @@ main (int argc, char *argv[], char *envp[])
   int should_netlink = DEFAULT_USE_NETLINK;
   int dry_run = DEFAULT_DRY_RUN;
   time_t last_success = 0;
+  int jitter = 0;
+  int wait_time = 0;
 
   /* Parse arguments */
   int opt;
-  while ((opt = getopt (argc, argv, "hwrpt:d:T:D:c:a:lsvm:")) != -1)
+  while ((opt = getopt (argc, argv, "hwrpt:d:T:D:c:a:lsvm:j:")) != -1)
     {
       switch (opt)
   {
@@ -365,6 +380,9 @@ main (int argc, char *argv[], char *envp[])
   case 'm':
     min_steady_state_interval = atoi (optarg);
     break;
+  case 'j':
+    jitter = atoi (optarg);
+    break;
   case 'h':
   default:
     usage (argv[0]);
@@ -391,6 +409,9 @@ main (int argc, char *argv[], char *envp[])
     fatal ("supplied base path is too long: '%s'", base_path);
   if (strlen (timestamp_path) + strlen (kTempSuffix) >= PATH_MAX)
     fatal ("supplied base path is too long: '%s'", base_path);
+  if (jitter >= steady_state_interval)
+    fatal ("jitter must be less than steady state interval (%d >= %d)",
+           jitter, steady_state_interval);
 
   /* grab a handle to /dev/rtc for sync_hwclock() */
   if (should_sync_hwclock && (hwclock_fd = open (DEFAULT_RTC_DEVICE, O_RDONLY)) < 0)
@@ -447,7 +468,8 @@ main (int argc, char *argv[], char *envp[])
    * this should handle cases like a VPN being brought up and down
    * periodically.
    */
-  while (wait_for_event (&rtc, should_netlink, steady_state_interval) >= 0)
+  wait_time = add_jitter(steady_state_interval, jitter);
+  while (wait_for_event (&rtc, should_netlink, wait_time) >= 0)
     {
       /*
        * If a route just came up, run tlsdate; if it
@@ -455,6 +477,7 @@ main (int argc, char *argv[], char *envp[])
        * from now on.
        */
       int i;
+      wait_time = add_jitter(steady_state_interval, jitter);
       if (time (NULL) - last_success < min_steady_state_interval)
         continue;
       for (i = 0; i < max_tries &&


### PR DESCRIPTION
We check for steady-state updates randomly at any time between
(base-jitter,base+jitter). The jitter is generated using libc rand(), seeded
with either some bytes from /dev/urandom (if available) or the time (if not). We
don't particularly need strong randomness here.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
(cherry picked from commit a8545b2af134f53247bd76507676bc0e3f1e6112)
