### PR TITLE
tlsdated: exponential backoff in error cases.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
     see ./configure --enable-code-coverage-checks and make lcov
   Don't hardfail if DEFAULT_RTC_DEVICE cannot be opened, even if desired
   Support -j to add jitter to tlsdated time checks.
+  Exponential backoff when tls connections fail.
 0.0.4 Wed 7 Nov, 2012
   Fixup CHANGELOG and properly tag
     Version Numbers Are Free! Hooray!

--- a/TODO
+++ b/TODO
@@ -38,7 +38,6 @@ Here is a nice list of things to do to improve tlsdate:
 41) Port to Mac OS X 10.8.2
      This work has started in a private branch
 42) Unit-test everything
-44) Exponential backoff
 45) Drop root from tlsdated
 46) Support multiple fetch hosts
 

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -39,6 +39,7 @@
 #define DEFAULT_SAVE_TO_DISK 1
 #define DEFAULT_USE_NETLINK 1
 #define DEFAULT_DRY_RUN 0
+#define MAX_SANE_BACKOFF 600 /* exponential backoff should only go this far */
 
 #ifndef TLSDATED_MAX_DATE
 #define TLSDATED_MAX_DATE 1999991337 /* this'll be a great bug some day */

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -477,13 +477,19 @@ main (int argc, char *argv[], char *envp[])
        * from now on.
        */
       int i;
+      int backoff = wait_between_tries;
       wait_time = add_jitter(steady_state_interval, jitter);
       if (time (NULL) - last_success < min_steady_state_interval)
         continue;
       for (i = 0; i < max_tries &&
-     tlsdate (tlsdate_argv, envp, subprocess_tries,
-        subprocess_wait_between_tries); ++i)
-  sleep (wait_between_tries);
+           tlsdate (tlsdate_argv, envp, subprocess_tries,
+           subprocess_wait_between_tries); ++i) {
+        if (backoff < 1)
+          fatal ("backoff too small? %d", backoff);
+        sleep (backoff);
+        if (backoff < MAX_SANE_BACKOFF)
+          backoff *= 2;
+      }
       if (i != max_tries)
   {
     last_success = time (NULL);


### PR DESCRIPTION
If we're failing to get a tls connection, it may be because the remote host is
down or overloaded, in which case our current aggressive retry behavior is
counterproductive; instead, do exponential backoff each time a tlsdate request
fails.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
