### PR TITLE
rwx permissions in save_disk_timestamp and write_time

### DIFF
--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -37,7 +37,7 @@ FIXTURE_TEARDOWN(tempdir) {
 }
 
 int write_time(const char *path, time_t time) {
-  int fd = open(path, O_WRONLY | O_TRUNC | O_CREAT, 0700);
+  int fd = open(path, O_WRONLY | O_TRUNC | O_CREAT, 0600);
   if (fd == -1)
     return 1;
   if (write(fd, &time, sizeof(time)) != sizeof(time)) {

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -138,7 +138,7 @@ save_disk_timestamp (const char *path, time_t t)
     }
 
   if ((fd = open (tmp, O_WRONLY | O_CREAT | O_NOFOLLOW | O_TRUNC,
-      S_IRWXU)) < 0)
+      S_IRUSR | S_IWUSR)) < 0)
     {
       pinfo ("open failed");
       return;


### PR DESCRIPTION
https://github.com/ioerror/tlsdate/issues/66

The function save_disk_timestamp creates a file with user read, write and execute permissions. The execute permission is unnecessary because it is guaranteed to be a file with the time_t in it.

The proper permission is S_IRUSR | S_IWUSR.

Similarly the function write_time in src/tlsdated-unittest.c creates a file with user read, write and execute permissions.
