### PR TITLE
tlsdated: support multiple failover hosts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
   Support -j to add jitter to tlsdated time checks.
   Exponential backoff when tls connections fail.
   Add config file support (have a look at man/tlsdated.conf.5)
+  Support multiple hosts for time fetches
 0.0.4 Wed 7 Nov, 2012
   Fixup CHANGELOG and properly tag
     Version Numbers Are Free! Hooray!

--- a/etc/tlsdated.conf
+++ b/etc/tlsdated.conf
@@ -18,6 +18,8 @@ verbose                            yes
 wait-between-tries                 10
 
 # Host configuration.
-host www.ptb.de
-port 443
-proxy none
+source
+	host www.ptb.de
+	port 443
+	proxy none
+end

--- a/man/tlsdated.conf.5
+++ b/man/tlsdated.conf.5
@@ -18,9 +18,6 @@ indicates that the option should be switched on, and all other values indicate
 that the option should be switched off. \fINote that trailing whitespace is
 preserved in values.\fR
 .SH OPTIONS
-.IP argv (string)
-Add an argument to the subprocess's argument vector. Use this option multiple
-times for multiple arguments.
 .IP base-path (string)
 Sets the path to tlsdated's cache directory.
 .IP dry-run (bool)
@@ -53,6 +50,19 @@ How many seconds to wait between each attempt to wait for the subprocess.
 If enabled, tlsdated will be annoyingly verbose in syslog and on stdout.
 .IP wait-between-tries (int)
 How long to wait between runs of the subprocess.
+.SH SOURCES
+You can list one or more sources to fetch time from. The format of these is:
+.RS 4
+source
+.RS 4
+host www.example.com
+.br
+port 443
+.br
+proxy socks5://127.0.0.1:9050
+.RE
+end
+.RE
 .SH BUGS
 It's likely! Let us know by contacting jacob@appelbaum.net
 

--- a/src/test/rotate.sh
+++ b/src/test/rotate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "args: $@"
+if [ "$2" = "host1" -a "$4" = "port1" -a "$6" = "proxy1" ]; then exit 1; fi
+if [ "$2" = "host2" -a "$4" = "port2" -a "$6" = "proxy2" ]; then exit 2; fi
+exit 3

--- a/src/test/sleep-wrap.sh
+++ b/src/test/sleep-wrap.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sleep $1

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -56,11 +56,39 @@ static const char kTestHost[] = { TEST_HOST, 0 };
 /** The current version of tlsdate. */
 #define tlsdate_version VERSION
 
+struct source {
+	struct source *next;
+	char *host;
+	char *port;
+	char *proxy;
+};
+
+struct opts {
+  int max_tries;
+  int min_steady_state_interval;
+  int wait_between_tries;
+  int subprocess_tries;
+  int subprocess_wait_between_tries;
+  int steady_state_interval;
+  const char *base_path;
+  char **base_argv;
+  char **argv;
+  int should_sync_hwclock;
+  int should_load_disk;
+  int should_save_disk;
+  int should_netlink;
+  int dry_run;
+  int jitter;
+  char *conf_file;
+  struct source *sources;
+  struct source *cur_source;
+};
+
 int is_sane_time (time_t ts);
 int load_disk_timestamp (const char *path, time_t * t);
 void save_disk_timestamp (const char *path, time_t t);
 int add_jitter (int base, int jitter);
-int tlsdate (char *argv[], char *envp[], int tries, int wait_between_tries);
+int tlsdate (struct opts *opts, char *argv[]);
 
 /** This is where we store parsed commandline options. */
 typedef struct {


### PR DESCRIPTION
Swap over to using 'source' stanzas in the config file (see tlsdated.conf for an
example), and cycle through them as we make tlsdate attempts.

TODO: changelog, man page, etc updates

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
