### PR TITLE
Fix 'make distcheck'.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ noinst_LTLIBRARIES=
 noinst_PROGRAMS=
 
 # GNU style is "make check", this will make check and test work
-TESTS+= $(check_PROGRAMS)
+TESTS+= src/conf_unittest src/tlsdated_unittest src/proxy-bio_unittest
 test: check
 
 ACLOCAL_AMFLAGS= -I m4

--- a/src/include.am
+++ b/src/include.am
@@ -63,3 +63,5 @@ noinst_HEADERS+= src/visibility.h
 noinst_HEADERS+= src/proxy-bio.h
 noinst_HEADERS+= src/test-bio.h
 noinst_HEADERS+= src/conf.h
+
+check_PROGRAMS+= src/test/rotate src/test/sleep-wrap

--- a/src/test/rotate.c
+++ b/src/test/rotate.c
@@ -1,0 +1,16 @@
+#include <string.h>
+
+int main(int argc, char *argv[])
+{
+  if (argc < 7)
+    return 3;
+  if (   !strcmp(argv[2], "host1")
+      && !strcmp(argv[4], "port1")
+      && !strcmp(argv[6], "proxy1"))
+    return 1;
+  if (   !strcmp(argv[2], "host2")
+      && !strcmp(argv[4], "port2")
+      && !strcmp(argv[6], "proxy2"))
+    return 2;
+  return 4;
+}

--- a/src/test/rotate.sh
+++ b/src/test/rotate.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-echo "args: $@"
-if [ "$2" = "host1" -a "$4" = "port1" -a "$6" = "proxy1" ]; then exit 1; fi
-if [ "$2" = "host2" -a "$4" = "port2" -a "$6" = "proxy2" ]; then exit 2; fi
-exit 3

--- a/src/test/sleep-wrap.c
+++ b/src/test/sleep-wrap.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[])
+{
+  if (argc < 2)
+    return 1;
+  sleep(atoi(argv[1]));
+  return 0;
+}

--- a/src/test/sleep-wrap.sh
+++ b/src/test/sleep-wrap.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-sleep $1

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -126,7 +126,7 @@ TEST(tlsdate_tests) {
   EXPECT_EQ(1, tlsdate(&opts, environ));
   args[0] = "/bin/true";
   EXPECT_EQ(0, tlsdate(&opts, environ));
-  args[0] = "src/test/sleep-wrap.sh";
+  args[0] = "src/test/sleep-wrap";
   args[1] = "3";
   EXPECT_EQ(-1, tlsdate(&opts, environ));
   opts.subprocess_wait_between_tries = 5;
@@ -163,7 +163,7 @@ TEST(rotate_hosts) {
     .proxy = "proxy1"
   };
   struct opts opts;
-  char *args[] = { "src/test/rotate.sh", NULL };
+  char *args[] = { "src/test/rotate", NULL };
   memset(&opts, 0, sizeof(opts));
   opts.sources = &s1;
   opts.base_argv = args;


### PR DESCRIPTION
Replace the silly test shell scripts with C programs, change the tlsdated
unittest to use the binaries instead, and have the Makefile install them as
needed.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
