### PR TITLE
Make sure we don't use locally generated configmake.h in Debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,3 +16,7 @@ override_dh_install:
 	
 	cp apparmor-profile debian/tlsdate/etc/apparmor.d/usr.bin.tlsdate
 	dh_apparmor --profile-name=usr.bin.tlsdate -ptlsdate
+
+override_dh_auto_clean:
+	dh_auto_clean
+	rm -f src/configmake.h


### PR DESCRIPTION
This will fix issue of cleaning up configmake.h in Debian build automatically.
