### PR TITLE
0.0.5-2 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+tlsdate (0.0.5-2) unstable; urgency=low
+
+  [Kartik Mistry]
+  * debian/control:
+    + Added Suggests: apparmor, as package ships an AppArmor profile.
+      Thanks to intrigeri@debian.org for report (Closes: #699181)
+    + Bumped Standards-Version to 3.9.4
+    + Added myself as Uploaders.
+  * debian/watch:
+    + Updated as per suggestion from Bart Martens <bartm@debian.org>.
+
+ -- Kartik Mistry <kartik@debian.org>  Wed, 30 Jan 2013 08:21:34 +0530
+
 tlsdate (0.0.5-1) unstable; urgency=low
 
   * New upstream version.

--- a/debian/control
+++ b/debian/control
@@ -2,17 +2,19 @@ Source: tlsdate
 Section: net
 Priority: extra
 Maintainer: Jacob Appelbaum <jacob@appelbaum.net>
+Uploaders: Kartik Mistry <kartik@debian.org>
 Build-Depends: autotools-dev,
                debhelper (>= 7.0.50~),
                dh-apparmor,
                hardening-wrapper,
                libssl-dev
-Standards-Version: 3.9.3
+Standards-Version: 3.9.4
 Homepage: https://www.github.com/ioerror/tlsdate/
 
 Package: tlsdate
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
+Suggests: apparmor
 Description: secure parasitic rdate replacement
  tlsdate sets the local clock by securely connecting with TLS to remote
  servers and extracting the remote time out of the secure handshake. Unlike

--- a/debian/watch
+++ b/debian/watch
@@ -1,4 +1,2 @@
 version=3
-
-# We will eventually want to put up new releases on github
-http://githubredir.debian.net/github/ioerror/tlsdate/archive/ tlsdate-(.*).tar.gz
+https://github.com/ioerror/tlsdate/tags .*/tlsdate-(\d[^n]*)\.(?:tgz|tbz2|txz|tar\.(?:gz|bz2|xz))


### PR DESCRIPTION
- debian/control:
  - Added Suggests: apparmor, as package ships an AppArmor profile.
    Thanks to intrigeri@debian.org for report (Closes: #699181)
  - Bumped Standards-Version to 3.9.4
  - Added myself as Uploaders.
- debian/watch:
  - Updated as per suggestion from Bart Martens bartm@debian.org.
