### PR TITLE
Fix looking up DNS Name fields if the CN doesn't match the hostname.

### DIFF
--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -483,7 +483,7 @@ check_cn (SSL *ssl, const char *hostname)
   ret = X509_NAME_get_text_by_NID(xname, NID_commonName,
                                   cn_buf, TLSDATE_HOST_NAME_MAX);
 
-  if (-1 == ret || ret != (int) strlen(hostname))
+  if (-1 == ret || ret != (int) strlen(cn_buf))
   {
     die ("Unable to extract commonName\n");
   }
@@ -579,7 +579,10 @@ check_san (SSL *ssl, const char *hostname)
             if (!strcasecmp(nval->name, "DNS"))
             {
               ok = check_wildcard_match_rfc2595(host, nval->value);
-              break;
+              if (ok)
+              {
+                break;
+              }
             }
             verb ("V: subjectAltName found but not matched: %s, type: %s\n", nval->value, nval->name); // XXX: Clean this string!
           }


### PR DESCRIPTION
There were two bugs:
1. `check_cn()` aborted when the data read from the CN field wasn't exactly
   length of the `hostname`. What makes more sense to check here is to make
   sure that the number of bytes read matches the length of the buffer it
   was read into, `cn_buf`.
2. `check_san()` didn't check any further DNS Names when the first didn't
   match as a wildcard name (the hostname needs to match on just one of
   the DNS Names, not all of them).
#45 reports the same problem as 2.

As an example, https://xnyhps.nl has a certificate with CN "www.xnyhps.nl", and DNS Names "www.xnyhps.nl" and "xnyhps.nl". Due to them being in that order, and `strlen("www.xnyhps.nl") != strlen("xnyhps.nl")`, the certificate is incorrectly rejected.
