### PR TITLE
tlsdated: support command-line proxy override

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.0.7 TBD
+  Add -x option to tlsdated to override source proxies.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/man/tlsdated.1
+++ b/man/tlsdated.1
@@ -50,6 +50,8 @@ be verbose
 print help message
 .IP "\-f [/path/to/config/file]"
 use alternate config file
+.IP "\-x [proxy]"
+override the proxy supplied to sources in the config file
 .IP "[tlsdate command]"
 arguments to be passed to tlsdate at launch time
 

--- a/src/include.am
+++ b/src/include.am
@@ -98,4 +98,4 @@ noinst_HEADERS+= src/proxy-polarssl.h
 noinst_HEADERS+= src/test-bio.h
 noinst_HEADERS+= src/conf.h
 
-check_PROGRAMS+= src/test/rotate src/test/sleep-wrap
+check_PROGRAMS+= src/test/proxy-override src/test/rotate src/test/sleep-wrap

--- a/src/test/proxy-override.c
+++ b/src/test/proxy-override.c
@@ -1,0 +1,14 @@
+#include <string.h>
+
+int main(int argc, char *argv[])
+{
+  int saw_good_proxy = 0;
+  while (argc--) {
+    if (!strcmp(argv[0], "socks5://good.proxy"))
+      saw_good_proxy = 1;
+    if (!strcmp(argv[0], "socks5://bad.proxy"))
+      return 2;
+    argv++;
+  }
+  return !saw_good_proxy;
+}

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -82,6 +82,7 @@ struct opts {
   char *conf_file;
   struct source *sources;
   struct source *cur_source;
+  char *proxy;
 };
 
 int is_sane_time (time_t ts);

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -176,4 +176,26 @@ TEST(rotate_hosts) {
   EXPECT_EQ(2, tlsdate(&opts, environ));
 }
 
+TEST(proxy_override) {
+  struct source s1 = {
+    .next = NULL,
+    .host = "host",
+    .port = "port",
+    .proxy = NULL,
+  };
+  struct opts opts;
+  char *args[] = { "src/test/proxy-override", NULL };
+  memset(&opts, 0, sizeof(opts));
+  opts.sources = &s1;
+  opts.base_argv = args;
+  opts.subprocess_tries = 2;
+  opts.subprocess_wait_between_tries = 1;
+  extern char **environ;
+  EXPECT_EQ(1, tlsdate(&opts, environ));
+  s1.proxy = "socks5://bad.proxy";
+  EXPECT_EQ(2, tlsdate(&opts, environ));
+  opts.proxy = "socks5://good.proxy";
+  EXPECT_EQ(0, tlsdate(&opts, environ));
+}
+
 TEST_HARNESS_MAIN

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -82,8 +82,10 @@ build_argv(struct opts *opts)
   new_argv[argc++] = opts->cur_source->host;
   new_argv[argc++] = (char *) "-p";
   new_argv[argc++] = opts->cur_source->port;
-  new_argv[argc++] = (char *) "-x";
-  new_argv[argc++] = opts->cur_source->proxy;
+  if (opts->cur_source->proxy || opts->proxy) {
+    new_argv[argc++] = (char *) "-x";
+    new_argv[argc++] = opts->proxy ? opts->proxy : opts->cur_source->proxy;
+  }
   new_argv[argc++] = NULL;
   opts->argv = new_argv;
 }
@@ -375,6 +377,7 @@ usage (const char *progn)
   printf ("  -l        don't load disk timestamps\n");
   printf ("  -s        don't save disk timestamps\n");
   printf ("  -v        be verbose\n");
+  printf ("  -x <h>    set proxy for subprocs to h\n");
   printf ("  -h        this\n");
 }
 
@@ -402,6 +405,7 @@ set_conf_defaults(struct opts *opts)
   opts->conf_file = NULL;
   opts->sources = NULL;
   opts->cur_source = NULL;
+  opts->proxy = NULL;
 }
 
 void
@@ -409,7 +413,7 @@ parse_argv(struct opts *opts, int argc, char *argv[])
 {
   int opt;
 
-  while ((opt = getopt (argc, argv, "hwrpt:d:T:D:c:a:lsvm:j:f:")) != -1)
+  while ((opt = getopt (argc, argv, "hwrpt:d:T:D:c:a:lsvm:j:f:x:")) != -1)
     {
       switch (opt)
   {
@@ -458,6 +462,9 @@ parse_argv(struct opts *opts, int argc, char *argv[])
   case 'f':
     opts->conf_file = optarg;
     break;
+  case 'x':
+    opts->proxy = optarg;
+    break;
   case 'h':
   default:
     usage (argv[0]);
@@ -484,9 +491,11 @@ void add_source_to_conf(struct opts *opts, char *host, char *port, char *proxy)
   source->port = strdup (port);
   if (!source->port)
     fatal ("out of memory for port");
-  source->proxy = strdup (proxy);
-  if (!source->proxy)
-    fatal ("out of memory for proxy");
+  if (proxy) {
+    source->proxy = strdup (proxy);
+    if (!source->proxy)
+      fatal ("out of memory for proxy");
+  }
   if (!opts->sources) {
     opts->sources = source;
   } else {
@@ -506,7 +515,7 @@ parse_source(struct opts *opts, struct conf_entry *conf)
    * source
    *   host <host>
    *   port <port>
-   *   proxy <proxy>
+   *   [proxy <proxy>]
    * end
    */
   assert(!strcmp(conf->key, "source"));
@@ -517,17 +526,15 @@ parse_source(struct opts *opts, struct conf_entry *conf)
     else if (!strcmp(conf->key, "port"))
       port = conf->value;
     else if (!strcmp(conf->key, "proxy"))
-    {
       proxy = conf->value;
-    }
     else
       fatal ("malformed config: '%s' in source stanza", conf->key);
     conf = conf->next;
   }
   if (!conf)
     fatal ("unclosed source stanza");
-  if (!host || !port || !proxy)
-    fatal ("incomplete source stanza (needs host, port, proxy)");
+  if (!host || !port)
+    fatal ("incomplete source stanza (needs host, port)");
   add_source_to_conf(opts, host, port, proxy);
   return conf;
 }


### PR DESCRIPTION
This makes a proxy passed on the command line with -x supplant proxies for
configured sources, and makes the 'proxy' stanza in sources optional (in which
case we supply no proxy argument for them).

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
