### PR TITLE
tlsdate-helper: fix SAN checking

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.0.7 TBD
   Add -x option to tlsdated to override source proxies.
+  Correctly check SANs against target host when using proxies.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -567,9 +567,9 @@ check_san (SSL *ssl, const char *hostname)
           {
             nval = sk_CONF_VALUE_value(val, j);
             if ((!strcasecmp(nval->name, "DNS") &&
-                !strcasecmp(nval->value, host) ) ||
+                !strcasecmp(nval->value, hostname) ) ||
                 (!strcasecmp(nval->name, "iPAddress") &&
-                !strcasecmp(nval->value, host)))
+                !strcasecmp(nval->value, hostname)))
             {
               verb ("V: subjectAltName matched: %s, type: %s\n", nval->value, nval->name); // We matched this; so it's safe to print
               ok = 1;
@@ -578,7 +578,7 @@ check_san (SSL *ssl, const char *hostname)
             // Attempt to match subjectAltName DNS names
             if (!strcasecmp(nval->name, "DNS"))
             {
-              ok = check_wildcard_match_rfc2595(host, nval->value);
+              ok = check_wildcard_match_rfc2595(hostname, nval->value);
               if (ok)
               {
                 break;


### PR DESCRIPTION
Right now, SAN checking checks against the host we're opening a socket to
instead of the host we're actually trying to talk to, which is fine... as long
as we don't have a proxy. Note that this problem only manifests for hosts whose
CN is not equal to their hostname (so the default host of www.ptb.de is fine).

To observe the problem:
$ ssh -D 127.0.0.1:30000 somehost
$ tlsdate -H clients3.google.com -x socks5://127.0.0.1:30000
hostname verification failed for host 127.0.0.1!
child process failed in SSL handshake

With this fix, you instead see no output.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
