### PR TITLE
tlsdate-dbus-announce: use name and flush connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.0.7 TBD
   Add -x option to tlsdated to override source proxies.
   Correctly check SANs against target host when using proxies.
+  Fix a race in tlsdate-dbus-announce that can cause signal drops.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/src/tlsdate-dbus-announce.c
+++ b/src/tlsdate-dbus-announce.c
@@ -22,11 +22,14 @@ int main(void)
   conn = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
   if (!conn)
     return 1;
+  if (dbus_bus_request_name(conn, "org.torproject.tlsdate", 0, &error) < 0)
+    return 1;
   msg = dbus_message_new_signal("/org/torproject/tlsdate", "org.torproject.tlsdate", "TimeUpdated");
   if (!msg)
     return 1;
   if (!dbus_connection_send(conn, msg, &ignored))
     return 1;
+  dbus_connection_flush(conn);
   dbus_message_unref(msg);
   return 0;
 }


### PR DESCRIPTION
Have tlsdate-dbus-announce grab a well-known bus name before it sends its
signal, and have it wait for the signal to actually be sent over the bus before
exiting.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
