### PR TITLE
tlsdated: pass -l and -v through to tlsdate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
   Add -x option to tlsdated to override source proxies.
   Correctly check SANs against target host when using proxies.
   Fix a race in tlsdate-dbus-announce that can cause signal drops.
+  Support -l argument to tlsdated.
+  Pass -l and -v arguments from tlsdated to tlsdate.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/src/include.am
+++ b/src/include.am
@@ -98,4 +98,5 @@ noinst_HEADERS+= src/proxy-polarssl.h
 noinst_HEADERS+= src/test-bio.h
 noinst_HEADERS+= src/conf.h
 
-check_PROGRAMS+= src/test/proxy-override src/test/rotate src/test/sleep-wrap
+check_PROGRAMS+= src/test/proxy-override src/test/return-argc \
+                 src/test/rotate src/test/sleep-wrap

--- a/src/test/return-argc.c
+++ b/src/test/return-argc.c
@@ -1,0 +1,3 @@
+/* return-argc.c - returns argc */
+
+int main(int argc) { return argc; }

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -83,6 +83,7 @@ struct opts {
   struct source *sources;
   struct source *cur_source;
   char *proxy;
+  int leap;
 };
 
 int is_sane_time (time_t ts);

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -9,6 +9,7 @@
 
 #include "src/test_harness.h"
 #include "src/tlsdate.h"
+#include "src/util.h"
 
 #include <fcntl.h>
 #include <limits.h>
@@ -196,6 +197,25 @@ TEST(proxy_override) {
   EXPECT_EQ(2, tlsdate(&opts, environ));
   opts.proxy = "socks5://good.proxy";
   EXPECT_EQ(0, tlsdate(&opts, environ));
+}
+
+TEST(tlsdate_args) {
+  struct source s1 = {
+    .next = NULL,
+    .host = "host",
+    .port = "port",
+    .proxy = "proxy",
+  };
+  struct opts opts;
+  char *args[] = { "src/test/return-argc", NULL };
+  memset(&opts, 0, sizeof(opts));
+  opts.sources = &s1;
+  opts.base_argv = args;
+  opts.subprocess_tries = 2;
+  opts.subprocess_wait_between_tries = 1;
+  opts.leap = 1;
+  verbose = 1;
+  EXPECT_EQ(9, tlsdate(&opts, environ));
 }
 
 TEST_HARNESS_MAIN

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -72,8 +72,8 @@ build_argv(struct opts *opts)
   for (argc = 0; opts->base_argv[argc]; argc++)
     ;
   argc++; /* uncounted null terminator */
-  argc += 6;  /* -H host -p port -x proxy */
-  new_argv = (char **) malloc (argc * sizeof(char *));
+  argc += 8;  /* -H host -p port -x proxy -v -l */
+  new_argv = malloc (argc * sizeof(char *));
   if (!new_argv)
     fatal ("out of memory building argv");
   for (argc = 0; opts->base_argv[argc]; argc++)
@@ -86,6 +86,10 @@ build_argv(struct opts *opts)
     new_argv[argc++] = (char *) "-x";
     new_argv[argc++] = opts->proxy ? opts->proxy : opts->cur_source->proxy;
   }
+  if (verbose)
+    new_argv[argc++] = "-v";
+  if (opts->leap)
+    new_argv[argc++] = "-l";
   new_argv[argc++] = NULL;
   opts->argv = new_argv;
 }
@@ -406,6 +410,7 @@ set_conf_defaults(struct opts *opts)
   opts->sources = NULL;
   opts->cur_source = NULL;
   opts->proxy = NULL;
+  opts->leap = 0;
 }
 
 void
@@ -593,6 +598,8 @@ load_conf(struct opts *opts)
       verbose = e->value ? !strcmp(e->value, "yes") : 1;
     } else if (!strcmp (e->key, "source")) {
       e = parse_source(opts, e);
+    } else if (!strcmp (e->key, "leap")) {
+      opts->leap = e->value ? !strcmp(e->value, "yes") : 1;
     }
   }
 }


### PR DESCRIPTION
Supply these options to tlsdate as needed. The ultimate goal of these changes is
to avoid passing an arbitrary tlsdate argv to tlsdated.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
