### PR TITLE
tlsdated: log more aggressively

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   Fix a race in tlsdate-dbus-announce that can cause signal drops.
   Support -l argument to tlsdated.
   Pass -l and -v arguments from tlsdated to tlsdate.
+  Log more verbosely at tlsdated startup.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/src/tlsdated.c
+++ b/src/tlsdated.c
@@ -635,12 +635,21 @@ main (int argc, char *argv[], char *envp[])
   time_t last_success = 0;
   struct opts opts;
   int wait_time = 0;
+  struct timeval tv = { 0, 0 };
 
   set_conf_defaults(&opts);
   parse_argv(&opts, argc, argv);
   check_conf(&opts);
   load_conf(&opts);
   check_conf(&opts);
+
+  info ("started up, loaded config file");
+
+  if (!opts.should_load_disk || load_disk_timestamp (timestamp_path, &tv.tv_sec))
+    info ("sysclock %lu, no cached time", time(NULL));
+  else
+    info ("sysclock %lu, cached time %lu", time(NULL), tv.tv_sec);
+
   if (!opts.sources)
     add_source_to_conf(&opts, (char *) DEFAULT_HOST, (char *) DEFAULT_PORT,
                               (char *) DEFAULT_PROXY);
@@ -658,7 +667,6 @@ main (int argc, char *argv[], char *envp[])
 
   if (!is_sane_time (time (NULL)))
     {
-      struct timeval tv = { 0, 0 };
       /*
        * If the time is before the build timestamp, we're probably on
        * a system with a broken rtc. Try loading the timestamp off
@@ -728,6 +736,7 @@ main (int argc, char *argv[], char *envp[])
       }
     }
 
+  info ("exiting");
   return 1;
 }
 #endif /* !TLSDATED_MAIN */


### PR DESCRIPTION
Sometimes it's not clear from syslogs when tlsdated is starting and exiting, so
make it be explicit about these things when verbose. Also, dump both the cached
timestamp and the sysclock at startup.

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
