### PR TITLE
android build patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ stamp-h1
 config/
 src/.dirstamp
 src/compat/.dirstamp
+src/android/.dirstamp
 src/configmake.h
 src/tlsdate-helper.o
 src/tlsdate-helper

--- a/configure.ac
+++ b/configure.ac
@@ -193,8 +193,19 @@ case "$host" in
             [""|yes|no], [UNPRIV_GROUP="nogroup"],
             [*], [UNPRIV_GROUP=$with_unpriv_group])
     AC_DEFINE_UNQUOTED([UNPRIV_GROUP], ["${UNPRIV_GROUP}"], [Unprivileged group])
+    case "$host" in
+      *-linux-androideabi)
+        dnl This is for Android NDK as it is a special case of linux
+        AC_DEFINE(HAVE_ANDROID,1, [Defined if we are to build for an Android system])
+        AC_SUBST(HAVE_ANDROID, [1])
+        HAVE_ANDROID="yes"
+        ;;
+    esac
     ;;
 esac
+
+dnl Android conditional
+AM_CONDITIONAL(HAVE_ANDROID, test "x${HAVE_ANDROID}" = "xyes")
 
 AC_MSG_CHECKING([user/group to drop privs to])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,11 @@ tlsdated_CFLAGS = $(AM_CFLAGS) -DTLSDATED_MAIN
 tlsdated_unittest_SOURCES = routeup.c tlsdated-unittest.c util.c
 endif
 
+if HAVE_ANDROID_SYSTEM
+tlsdated_unittest_SOURCES += android/android.c android/fmemopen.c
+endif
+
+
 if TARGET_OSX
 tlsdated_SOURCES = routeup.c tlsdated.c util.c
 tlsdated_CFLAGS = $(AM_CFLAGS) -DTLSDATED_MAIN
@@ -70,3 +75,8 @@ endif
 
 # We're not shipping headers
 noinst_HEADERS = tlsdate.h
+
+if HAVE_ANDROID_SYSTEM
+noinst_HEADERS+= android/android.h
+noinst_HEADERS+= android/fmemopen.h
+endif

--- a/src/android/android.c
+++ b/src/android/android.c
@@ -1,0 +1,18 @@
+#include "android.h"
+
+#include <string.h>
+
+char *strchrnul(const char *s, int c)
+{
+   char * matched_char = strchr(s, c);
+   if (matched_char == NULL) {
+       matched_char = (char*) s + strlen(s);
+   }
+   return matched_char;
+}
+
+int MIN(int a, int b) {
+    return a < b ? a : b;
+}
+
+

--- a/src/android/android.h
+++ b/src/android/android.h
@@ -1,0 +1,25 @@
+/*
+ * Android's libc lacks fmemopen, so here is our implementation.
+ */
+
+#include <stdio.h>
+
+/**
+ * fmemopen expects this function
+ * defined in android.c
+ */
+int MIN(int a, int b);
+
+
+/*
+ * Android's libc does not provide strchrnul, so here
+ * is our own implementation. strchrnul behaves like
+ * strchr except instead of returning NULL if c is not
+ * in s, strchrnul returns a pointer to the \0 byte at
+ * the end of s.
+ * defined in android.c
+ */
+char *strchrnul(const char *s, int c);
+
+/* defined in fmemopen.c */
+FILE *fmemopen(void *buf, size_t size, const char *mode);

--- a/src/android/fmemopen.c
+++ b/src/android/fmemopen.c
@@ -1,0 +1,225 @@
+/*
+   This file was retrieved from
+       http://gitweb.dragonflybsd.org/dragonfly.git/blob_plain/HEAD:/lib/libc/stdio/fmemopen.c
+    on 26/04/2013 by Abel Luck for inclusion in tlsdate for the Android port.
+*/
+#include "android.h"
+/* $NetBSD: fmemopen.c,v 1.4 2010/09/27 16:50:13 tnozaki Exp $ */
+
+/*-
+ * Copyright (c)2007, 2010 Takehiko NOZAKI,
+ * Copyright (c) 2012, Venkatesh Srinivas <vsrinivas@dragonflybsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+//#include "local.h"
+//#include "priv_stdio.h"
+
+struct fmemopen_cookie {
+    char *head, *tail, *cur, *eob;
+};
+
+static int
+fmemopen_read(void *cookie, char *buf, int nbytes)
+{
+    struct fmemopen_cookie *p;
+    char *s;
+    int len;
+
+    assert(cookie != NULL);
+    assert(buf != NULL && nbytes > 0);
+
+    p = cookie;
+    s = p->cur;
+    len = MIN(p->tail - p->cur, nbytes);
+    bcopy(p->cur, buf, len);
+    p->cur += len;
+
+    return (int)(p->cur - s);
+}
+
+static int
+fmemopen_write(void *cookie, const char *buf, int nbytes)
+{
+    struct fmemopen_cookie *p;
+    char *s;
+    int len;
+
+    assert(cookie != NULL);
+    assert(buf != NULL && nbytes > 0);
+
+    p = cookie;
+    if (p->cur >= p->tail)
+        return 0;
+    s = p->cur;
+
+    len = MIN(p->tail - p->cur, nbytes);
+
+    bcopy(buf, p->cur, len);
+
+    p->cur += len - 1;
+    if (p->cur == p->tail - 1) {
+        *p->cur = '\0';
+        if (buf[len - 1] == '\0')
+            p->cur++;
+    } else {
+        *++p->cur = '\0';
+    }
+
+    if (p->cur > p->eob)
+        p->eob = p->cur;
+
+    return (int)(p->cur - s);
+}
+
+static fpos_t
+fmemopen_seek(void *cookie, fpos_t offset, int whence)
+{
+    struct fmemopen_cookie *p;
+
+    assert(cookie != NULL);
+
+    p = (struct fmemopen_cookie *)cookie;
+    switch (whence) {
+    case SEEK_SET:
+        break;
+    case SEEK_CUR:
+        offset += p->cur - p->head;
+        break;
+    case SEEK_END:
+        offset += p->eob - p->head;
+        break;
+    default:
+        errno = EINVAL;
+        goto error;
+    }
+    if (offset >= (fpos_t)0 && offset <= p->tail - p->head) {
+        p->cur = p->head + (ptrdiff_t)offset;
+        return (fpos_t)(p->cur - p->head);
+    }
+error:
+    return (fpos_t)-1;
+}
+
+static int
+fmemopen_close0(void *cookie)
+{
+    assert(cookie != NULL);
+
+    free(cookie);
+
+    return 0;
+}
+
+static int
+fmemopen_close1(void *cookie)
+{
+    struct fmemopen_cookie *p;
+
+    assert(cookie != NULL);
+
+    p = cookie;
+    free(p->head);
+    free(p);
+
+    return 0;
+}
+
+
+FILE *
+fmemopen(void * __restrict buf, size_t size, const char * __restrict mode)
+{
+    int flags, oflags;
+    FILE *fp;
+    struct fmemopen_cookie *cookie;
+
+    if (size < (size_t)1)
+        goto invalid;
+
+    flags = __sflags(mode, &oflags);
+    if (flags == 0)
+        return NULL;
+
+    if ((oflags & O_RDWR) == 0 && buf == NULL)
+        goto invalid;
+
+    fp = __sfp();
+    if (fp == NULL)
+        return NULL;
+
+    cookie = malloc(sizeof(*cookie));
+    if (cookie == NULL)
+        goto release;
+
+    if (buf == NULL) {
+        cookie->head = malloc(size);
+        if (cookie->head == NULL) {
+            free(cookie);
+            goto release;
+        }
+        *cookie->head = '\0';
+        fp->_close = &fmemopen_close1;
+    } else {
+        cookie->head = (char *)buf;
+        if (oflags & O_TRUNC)
+            *cookie->head = '\0';
+        fp->_close = &fmemopen_close0;
+    }
+
+    cookie->tail = cookie->head + size;
+    cookie->eob  = cookie->head;
+    do {
+        if (*cookie->eob == '\0')
+            break;
+        ++cookie->eob;
+    } while (--size > 0);
+
+    cookie->cur = (oflags & O_APPEND) ? cookie->eob : cookie->head;
+
+    // fp->pub._flags  = flags;
+    fp->_write  = (flags & __SRD) ? NULL : &fmemopen_write;
+    fp->_read   = (flags & __SWR) ? NULL : &fmemopen_read;
+    fp->_seek   = &fmemopen_seek;
+    fp->_cookie = (void *)cookie;
+
+    return fp;
+
+invalid:
+    errno = EINVAL;
+    return NULL;
+
+release:
+    //fp->pub._flags = 0;
+    return NULL;
+}
+
+

--- a/src/conf-unittest.c
+++ b/src/conf-unittest.c
@@ -13,6 +13,10 @@
 #include "src/conf.h"
 #include "src/test_harness.h"
 
+#ifdef HAVE_ANDROID_SYSTEM
+#include "src/android/fmemopen.h"
+#endif
+
 FILE *fopenstr(const char *str) {
   /* strlen(str) instead of strlen(str) + 1 because files shouldn't appear
    * null-terminated. Cast away constness because we're in read mode, but the

--- a/src/conf.c
+++ b/src/conf.c
@@ -10,6 +10,11 @@
 
 #include "src/conf.h"
 
+#include "config.h"
+#ifdef HAVE_ANDROID
+#include "src/android/android.h"
+#endif
+
 void strip_newlines(char *line)
 {
   *strchrnul(line, '\n') = '\0';

--- a/src/include.am
+++ b/src/include.am
@@ -19,6 +19,11 @@ bin_PROGRAMS+= src/tlsdate-dbus-announce
 
 src_conf_unittest_SOURCES = src/conf.c
 src_conf_unittest_SOURCES+= src/conf-unittest.c
+
+if HAVE_ANDROID
+src_conf_unittest_SOURCES+= src/android/android.c src/android/fmemopen.c
+endif
+
 check_PROGRAMS+= src/conf_unittest
 noinst_PROGRAMS+= src/conf_unittest
 endif
@@ -65,7 +70,13 @@ src_tlsdate_helper_SOURCES+= src/util.c
 if TARGET_LINUX
 src_tlsdated_CFLAGS = -DTLSDATED_MAIN @SSL_CFLAGS@
 src_tlsdated_LDADD = @SSL_LIBS@
-src_tlsdated_SOURCES = src/conf.c
+src_tlsdated_SOURCES = 
+
+if HAVE_ANDROID
+src_tlsdated_SOURCES+= src/android/android.c
+endif
+
+src_tlsdated_SOURCES+= src/conf.c
 src_tlsdated_SOURCES+= src/routeup.c
 src_tlsdated_SOURCES+= src/tlsdated.c
 src_tlsdated_SOURCES+= src/util.c
@@ -119,6 +130,10 @@ noinst_HEADERS+= src/proxy-bio.h
 noinst_HEADERS+= src/proxy-polarssl.h
 noinst_HEADERS+= src/test-bio.h
 noinst_HEADERS+= src/conf.h
+
+if HAVE_ANDROID
+noinst_HEADERS+= src/android/android.h
+endif
 
 check_PROGRAMS+= src/test/proxy-override src/test/return-argc \
                  src/test/rotate src/test/sleep-wrap


### PR DESCRIPTION
Android's libc lacks several functions required by tlsdate, so I've
dropped implementations of them in src/android and conditionally included
them where necessary.
