### PR TITLE
Check for <sys/socket.h> in configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,7 @@ AC_CHECK_HEADERS([stdint.h], ,[AC_MSG_ERROR([Required headers missing; compilati
 AC_CHECK_HEADERS([stdio.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([stdlib.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([sys/mman.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
+AC_CHECK_HEADERS([sys/socket.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([sys/time.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([sys/types.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([sys/wait.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])


### PR DESCRIPTION
Avoids redefinition of SHUT_\* constants in config.h fragment provided
by AX_PLATFORM.
