### PR TITLE
Cast char to unsigned char before passing to ctype(3) isXYZ.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -31,7 +31,7 @@ void strip_newlines(char *line)
 
 char *eat_whitespace(char *line)
 {
-  while (isspace(*line))
+  while (isspace((int)(unsigned char)*line))
     line++;
   return line;
 }

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -122,7 +122,7 @@ static void
 validate_proxy_port(const char *port)
 {
   while (*port)
-    if (!isdigit(*port++))
+    if (!isdigit((int)(unsigned char)*port++))
       die("invalid char in port\n");
 }
 


### PR DESCRIPTION
The ctype(3) routines take an int, but the only valid arguments are
EOF and values representable as unsigned char.  This is what you get
out of, e.g., getc(3), but an arbitrary value of type char is not OK
because negative values will lead to nasal demons.  Converting an
arbitrary value of type char to unsigned char is OK, since then we
have only non-negative values, and casting that to int makes it
clearer what's going on.
