### PR TITLE
Implement strnlen locally if the system libc doesn't have it.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,9 @@ AC_CHECK_HEADERS([sys/wait.h], ,[AC_MSG_ERROR([Required headers missing; compila
 AC_CHECK_HEADERS([time.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 AC_CHECK_HEADERS([unistd.h], ,[AC_MSG_ERROR([Required headers missing; compilation will not succeed])])
 
+AC_CHECK_FUNCS([strnlen])
+AM_CONDITIONAL(HAVE_STRNLEN, [test "x${ac_cv_func_strnlen}" = xyes])
+
 AC_CHECK_FUNCS([setresuid])
 AC_CHECK_FUNCS([gettimeofday])
 

--- a/src/common/strnlen.c
+++ b/src/common/strnlen.c
@@ -1,0 +1,19 @@
+/*
+ * Trivial strnlen(3) implementation
+ */
+
+#include <stddef.h>
+
+#include "strnlen.h"
+
+size_t
+strnlen(const char *s, size_t limit)
+{
+  size_t len;
+
+  for (len = 0; len < limit; len++)
+    if (*s++ == '\0')
+      break;
+
+  return len;
+}

--- a/src/common/strnlen.h
+++ b/src/common/strnlen.h
@@ -1,0 +1,8 @@
+#ifndef	TLSDATE_STRNLEN_H
+#define	TLSDATE_STRNLEN_H
+
+#include <stddef.h>
+
+size_t strnlen(const char *, size_t);
+
+#endif  /* TLSDATE_STRNLEN_H */

--- a/src/include.am
+++ b/src/include.am
@@ -103,6 +103,10 @@ src_tlsdate_helper_SOURCES+= src/proxy-bio.c
 endif
 src_tlsdate_helper_SOURCES+= src/util.c
 
+if !HAVE_STRNLEN
+src_tlsdate_helper_SOURCES+= src/common/strnlen.c
+endif
+
 # This doesn't work on Mac OS X
 if TARGET_LINUX
 src_tlsdated_CFLAGS = -DTLSDATED_MAIN @SSL_CFLAGS@
@@ -164,6 +168,13 @@ src_proxy_bio_unittest_SOURCES+= src/proxy-bio-unittest.c
 src_proxy_bio_unittest_SOURCES+= src/test-bio.c
 src_proxy_bio_unittest_SOURCES+= src/util.c
 src_proxy_bio_unittest_SOURCES+= src/common/android.c
+
+# XXX This conditional should apply for any system where we're building
+# proxy_bio_unittest, but I don't know how to tell that to automake.
+if !HAVE_STRNLEN
+src_proxy_bio_unittest_SOURCES+= src/common/strnlen.c
+endif
+
 check_PROGRAMS+= src/proxy-bio_unittest
 noinst_PROGRAMS+= src/proxy-bio_unittest
 endif

--- a/src/proxy-bio.c
+++ b/src/proxy-bio.c
@@ -17,6 +17,8 @@
  * SSL.
  */
 
+#include "config.h"
+
 #include <arpa/inet.h>
 #include <assert.h>
 #ifndef __USE_MISC
@@ -28,6 +30,10 @@
 #include <netdb.h>
 
 #include <stdint.h>
+
+#ifndef HAVE_STRNLEN
+#include "src/common/strnlen.h"
+#endif
 
 #include "src/proxy-bio.h"
 

--- a/src/proxy-polarssl.c
+++ b/src/proxy-polarssl.c
@@ -12,6 +12,8 @@
  * This file implements a SOCKS4a/SOCKS5 net layer as used by PolarSSL.
  */
 
+#include "config.h"
+
 #include <arpa/inet.h>
 #include <assert.h>
 #ifndef __USE_MISC
@@ -23,6 +25,10 @@
 #include <netdb.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#ifndef HAVE_STRNLEN
+#include "src/common/strnlen.h"
+#endif
 
 #include "src/proxy-polarssl.h"
 #include "src/util.h"


### PR DESCRIPTION
Needed for, and currently built only on, NetBSD 5.
