### PR TITLE
tlsdated: remove rmrf()

### DIFF
--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -27,14 +27,13 @@ FIXTURE_SETUP(tempdir) {
   ASSERT_NE(NULL, p);
 }
 
-int rmrf(char *dir) {
-  char buf[256];
-  snprintf(buf, sizeof(buf), "rm -rf %s", dir);
-  return system(buf);
-}
-
 FIXTURE_TEARDOWN(tempdir) {
-  ASSERT_EQ(0, rmrf(self->path));
+  char buf[256];
+  snprintf(buf, sizeof(buf), "%s/load", self->path);
+  unlink(buf);
+  snprintf(buf, sizeof(buf), "%s/save", self->path);
+  unlink(buf);
+  ASSERT_EQ(0, rmdir(self->path));
 }
 
 int write_time(const char *path, time_t time) {


### PR DESCRIPTION
This function, while handy and presently used safely, could become dangerous if
someone later adds a call to it that passes in attacker-controlled input.
Therefore, hardcode calls to unlink(2) and rmdir(2) for the files tlsdated
presently creates. This has the pleasant (?) side-effect of breaking unit-tests
whenever tlsdated creates files we don't explicitly list on disk.

BUG=tlsdate #65
TEST=unit

Signed-off-by: Elly Fong-Jones ellyjones@chromium.org
