### PR TITLE
Fix subprocess watching.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
   Add Mac OS X 10.8.3 support
   Extensive setup/install documentation is now present in INSTALL for most OSes
   Add DragonFly BSD 3.3 support
+  Refactored subprocess watching.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/etc/tlsdated.conf
+++ b/etc/tlsdated.conf
@@ -12,8 +12,7 @@ should-netlink                     yes
 should-save-disk                   yes
 should-sync-hwclock                yes
 steady-state-interval              86400
-subprocess-tries                   10
-subprocess-wait-between-tries      3
+subprocess-timeout                 30
 verbose                            yes
 wait-between-tries                 10
 

--- a/man/tlsdated.conf.5
+++ b/man/tlsdated.conf.5
@@ -42,10 +42,8 @@ at exit.
 If enabled, set the hwclock to the fetched time.
 .IP "steady-state-interval [int]"
 Check at least once this many seconds when in steady state.
-.IP "subprocess-tries [int]"
-How many times to try waiting for the subprocess.
-.IP "subprocess-wait-between-tries [int]"
-How many seconds to wait between each attempt to wait for the subprocess.
+.IP "subprocess-timeout [int]"
+How many seconds to wait for the subprocess to exit.
 .IP "verbose [bool]"
 If enabled, tlsdated will be annoyingly verbose in syslog and on stdout.
 .IP "wait-between-tries [int]"

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -33,8 +33,7 @@
 /* tlsdated magic numbers */
 #define MAX_TRIES 10
 #define WAIT_BETWEEN_TRIES 10
-#define SUBPROCESS_TRIES 10
-#define SUBPROCESS_WAIT_BETWEEN_TRIES 3
+#define SUBPROCESS_TIMEOUT 30
 #define STEADY_STATE_INTERVAL 86400
 #define DEFAULT_SYNC_HWCLOCK 1
 #define DEFAULT_LOAD_FROM_DISK 1
@@ -67,8 +66,7 @@ struct opts {
   int max_tries;
   int min_steady_state_interval;
   int wait_between_tries;
-  int subprocess_tries;
-  int subprocess_wait_between_tries;
+  int subprocess_timeout;
   int steady_state_interval;
   const char *base_path;
   char **base_argv;

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -118,8 +118,7 @@ TEST(tlsdate_tests) {
   memset(&opts, 0, sizeof(opts));
   opts.sources = &source;
   opts.base_argv = args;
-  opts.subprocess_tries = 2;
-  opts.subprocess_wait_between_tries = 1;
+  opts.subprocess_timeout = 1;
   extern char **environ;
   EXPECT_EQ(1, tlsdate(&opts, environ));
   args[0] = "/bin/false";
@@ -129,7 +128,7 @@ TEST(tlsdate_tests) {
   args[0] = "src/test/sleep-wrap";
   args[1] = "3";
   EXPECT_EQ(-1, tlsdate(&opts, environ));
-  opts.subprocess_wait_between_tries = 5;
+  opts.subprocess_timeout = 5;
   EXPECT_EQ(0, tlsdate(&opts, environ));
 }
 
@@ -167,8 +166,7 @@ TEST(rotate_hosts) {
   memset(&opts, 0, sizeof(opts));
   opts.sources = &s1;
   opts.base_argv = args;
-  opts.subprocess_tries = 2;
-  opts.subprocess_wait_between_tries = 1;
+  opts.subprocess_timeout = 2;
   extern char **environ;
   EXPECT_EQ(1, tlsdate(&opts, environ));
   EXPECT_EQ(2, tlsdate(&opts, environ));
@@ -188,8 +186,7 @@ TEST(proxy_override) {
   memset(&opts, 0, sizeof(opts));
   opts.sources = &s1;
   opts.base_argv = args;
-  opts.subprocess_tries = 2;
-  opts.subprocess_wait_between_tries = 1;
+  opts.subprocess_timeout = 2;
   extern char **environ;
   EXPECT_EQ(1, tlsdate(&opts, environ));
   s1.proxy = "socks5://bad.proxy";
@@ -210,8 +207,7 @@ TEST(tlsdate_args) {
   memset(&opts, 0, sizeof(opts));
   opts.sources = &s1;
   opts.base_argv = args;
-  opts.subprocess_tries = 2;
-  opts.subprocess_wait_between_tries = 1;
+  opts.subprocess_timeout = 2;
   opts.leap = 1;
   verbose = 1;
   EXPECT_EQ(9, tlsdate(&opts, environ));

--- a/src/util.h
+++ b/src/util.h
@@ -37,4 +37,8 @@ static inline int min(int x, int y) { return x < y ? x : y; }
 
 void drop_privs_to (const char *user, const char *group);
 
+/* like wait(), but with a timeout. Returns ordinary fork() error codes, or
+ * ETIMEDOUT. */
+pid_t wait_with_timeout(int *status, int timeout_secs);
+
 #endif /* !UTIL_H */


### PR DESCRIPTION
Currently, the subprocess watching code polls with a delay between attempts.
Instead, introduce wait_with_timeout() and use it, simplifying this code.

Signed-off-by: Elly Fong-Jones elly@leptoquark.net
