### PR TITLE
Refactor event loop.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@
   Add DragonFly BSD 3.3 support
   Refactored subprocess watching.
   Added integration tests. Run with ./run-tests
+  Refactored event loop.
+  Added suspend/resume RTC corruption detection.
 0.0.6 Mon 18 Feb, 2013
   Ensure that tlsdate compiles with g++ by explicit casting rather than
   implicit casting by whatever compiler is compiling tlsdate.

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ if !TARGET_OSX
 # GNU style is "make check", this will make check and test work
 TESTS+= src/conf_unittest src/proxy-bio_unittest
 if TARGET_LINUX
-TESTS+= src/tlsdated_unittest
+TESTS+= src/tlsdated_unittest src/event_unittest
 endif
 test: check
 endif

--- a/run-tests
+++ b/run-tests
@@ -5,9 +5,9 @@ run_test() {
 	if [ -r "$1"/tlsdated-flags ]; then
 		flags=$(cat "$1"/tlsdated-flags | sed "s/@TESTDIR@/$1/g")
 	elif [ -r "$1"/test.conf ]; then
-		flags="-w -p -r -l -s -f $1/test.conf"
+		flags="-w -p -r -l -s -f $1/test.conf -v"
 	else
-		flags="-w -p -r -l -s -f test.conf"
+		flags="-w -p -r -l -s -f test.conf -v"
 	fi
 	# flags are deliberately unquoted here so that they'll be interpolated
 	timeout 5 src/tlsdated $flags -- "$1"/subproc.sh <"$1"/input >"$1"/run-output \

--- a/src/event-unittest.c
+++ b/src/event-unittest.c
@@ -1,0 +1,48 @@
+#include "src/event.h"
+#include "src/test_harness.h"
+
+#include <sys/time.h>
+
+TEST(every) {
+	struct event *e = event_every(3);
+	time_t then = time(NULL);
+	time_t now;
+	EXPECT_EQ(1, event_wait(e));
+	now = time(NULL);
+	EXPECT_GT(now, then + 2);
+	event_free(e);
+}
+
+TEST(fdread) {
+	int fds[2];
+	struct event *e;
+	char z = '0';
+
+	ASSERT_EQ(0, pipe(fds));
+	e = event_fdread(fds[0]);
+
+	write(fds[1], &z, 1);
+	EXPECT_EQ(1, event_wait(e));
+	event_free(e);
+}
+
+TEST(composite) {
+	struct event *e0 = event_every(2);
+	struct event *e1 = event_every(3);
+	struct event *ec = event_composite();
+	time_t then = time(NULL);
+	time_t now;
+
+	ASSERT_EQ(0, event_composite_add(ec, e0));
+	ASSERT_EQ(0, event_composite_add(ec, e1));
+	EXPECT_EQ(1, event_wait(ec));
+	EXPECT_EQ(1, event_wait(ec));
+	EXPECT_EQ(1, event_wait(ec));
+	now = time(NULL);
+	EXPECT_EQ(now, then + 4);
+	event_free(ec);
+	event_free(e1);
+	event_free(e0);
+}
+
+TEST_HARNESS_MAIN

--- a/src/event.c
+++ b/src/event.c
@@ -1,0 +1,295 @@
+#include <assert.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "routeup.h"
+
+struct event {
+  const char *name;
+  int (*fd)(struct event *);
+  int (*wait)(struct event *);
+  void (*free)(struct event *);
+};
+
+struct event_fd {
+  struct event event;
+  int fd;
+  pid_t pid;
+};
+
+struct event_composite {
+  struct event event;
+  struct event **children;
+  size_t nchildren;
+};
+
+static int _subproc_fd(struct event *e)
+{
+  struct event_fd *efd = (struct event_fd *)e;
+  return efd->fd;
+}
+
+static int _subproc_wait(struct event *e)
+{
+  struct event_fd *efd = (struct event_fd *)e;
+  char buf;
+  if (read(_subproc_fd(e), &buf, 1) == 1)
+    return 1;
+  /* fd is broken...? */
+  close(efd->fd);
+  efd->fd = -1;
+  return -1;
+}
+
+static const char kZero = '0';
+
+static void _subproc_signal(int fd)
+{
+  ssize_t _unused = write(fd, &kZero, 1);
+  (void)_unused;
+}
+
+static void _subproc_free(struct event *e)
+{
+  struct event_fd *efd = (struct event_fd *)e;
+  if (efd->pid > 0) {
+    kill(efd->pid, SIGKILL);
+    waitpid(efd->pid, NULL, 0);
+  }
+  close(efd->fd);
+  free(efd);
+}
+
+static struct event *_event_subproc(void (*func)(void *, int), void *arg)
+{
+  struct event_fd *ev = malloc(sizeof *ev);
+  int fds[2];
+
+  if (!ev)
+    return NULL;
+
+  ev->event.fd = _subproc_fd;
+  ev->event.wait = _subproc_wait;
+  ev->event.free = _subproc_free;
+
+  if (pipe(fds))
+  {
+    free(ev);
+    return NULL;
+  }
+
+  ev->pid = fork();
+  if (ev->pid < 0)
+  {
+    close(fds[0]);
+    close(fds[1]);
+    free(ev);
+    return NULL;
+  }
+  else if (ev->pid == 0)
+  {
+    close(fds[0]);
+    func(arg, fds[1]);
+    exit(0);
+  }
+
+  close(fds[1]);
+  ev->fd = fds[0];
+
+  return &ev->event;
+}
+
+static void _routeup(void *arg, int fd)
+{
+  struct routeup *rtup = arg;
+  while (!routeup_once(rtup, 0))
+    _subproc_signal(fd);
+}
+
+struct event *event_routeup()
+{
+  struct routeup *rtup = malloc(sizeof *rtup);
+  struct event *e;
+  if (!rtup)
+    return NULL;
+  if (!routeup_setup(rtup))
+  {
+    free(rtup);
+    return NULL;
+  }
+  e = _event_subproc(_routeup, (void*)rtup);
+  /* free it in the parent only */
+  routeup_teardown(rtup);
+  if (e)
+    e->name = "routeup";
+  return e;
+}
+
+static void _every(void *arg, int fd)
+{
+  int delay = *(int*)arg;
+  while (1)
+  {
+    sleep(delay);
+    _subproc_signal(fd);
+  }
+}
+
+struct event *event_every(int seconds)
+{
+  struct event *e = _event_subproc(_every, (void *)&seconds);
+  e->name = "every";
+  return e;
+}
+
+static void _suspend(void *arg, int fd)
+{
+  while (1)
+  {
+    static const int kInterval = 60;
+    static const int kThreshold = 3;
+    time_t then = time(NULL);
+    time_t now;
+    sleep(kInterval);
+    now = time(NULL);
+    if (abs(now - then - kInterval) > kThreshold)
+      _subproc_signal(fd);
+  }
+}
+
+struct event *event_suspend()
+{
+  struct event *e = _event_subproc(_suspend, NULL);
+  e->name = "suspend";
+  return e;
+}
+
+struct event *event_fdread(int fd)
+{
+  struct event_fd *efd = malloc(sizeof *efd);
+  efd->event.name = "fdread";
+  efd->event.fd = _subproc_fd;
+  efd->event.wait = _subproc_wait;
+  efd->event.free = _subproc_free;
+  efd->fd = fd;
+  return &efd->event;
+}
+
+int event_wait(struct event *e)
+{
+  assert(e->wait);
+  return e->wait(e);
+}
+
+void event_free(struct event *e)
+{
+  assert(e->free);
+  return e->free(e);
+}
+
+static int _composite_fd(struct event *e)
+{
+  return -1;
+}
+
+static int _composite_wait(struct event *e)
+{
+  struct event_composite *ec = (struct event_composite *)e;
+  fd_set fds;
+  size_t i;
+  int n;
+  int maxfd = -1;
+
+  FD_ZERO(&fds);
+  for (i = 0; i < ec->nchildren; i++)
+  {
+    struct event *child = ec->children[i];
+    int fd = child->fd(child);
+    if (fd != -1)
+      FD_SET(child->fd(child), &fds);
+    if (fd > maxfd)
+      maxfd = fd;
+  }
+
+  n = select(maxfd + 1, &fds, NULL, NULL, NULL);
+  if (n < 0)
+    return -1;
+  for (i = 0; i < ec->nchildren; i++)
+  {
+    struct event *child = ec->children[i];
+    int fd = child->fd(child);
+    if (FD_ISSET(fd, &fds))
+    {
+      /* won't block, but clears the event */
+      int r = child->wait(child);
+      if (r)
+        /* either error or success, but not 'no event' */
+        return r;
+    }
+  }
+
+  return 0;
+}
+
+static void _composite_free(struct event *e)
+{
+  struct event_composite *ec = (struct event_composite *)e;
+  free(ec->children);
+  free(ec);
+}
+
+struct event *event_composite(void)
+{
+  struct event_composite *ec = malloc(sizeof *ec);
+  if (!ec)
+    return NULL;
+  ec->event.name = "composite";
+  ec->event.fd = _composite_fd;
+  ec->event.wait = _composite_wait;
+  ec->event.free = _composite_free;
+  ec->children = NULL;
+  ec->nchildren = 0;
+  return &ec->event;
+}
+
+int event_composite_add(struct event *comp, struct event *e)
+{
+  struct event_composite *ec = (struct event_composite *)comp;
+  size_t i;
+  size_t nsz;
+  struct event **nch;
+  for (i = 0; i < ec->nchildren; i++)
+  {
+    if (ec->children[i])
+      continue;
+    ec->children[i] = e;
+    return 0;
+  }
+  nsz = ec->nchildren + 1;
+  nch = realloc(ec->children, nsz * sizeof(struct event *));
+  if (!nch)
+    return 1;
+  ec->nchildren = nsz;
+  ec->children = nch;
+  ec->children[nsz - 1] = e;
+  return 0;
+}
+
+int event_composite_del(struct event *comp, struct event *e)
+{
+  struct event_composite *ec = (struct event_composite *)comp;
+  size_t i;
+  for (i = 0; i < ec->nchildren; i++)
+  {
+    if (ec->children[i] != e)
+      continue;
+    ec->children[i] = NULL;
+    return 0;
+  }
+  return 1;
+}

--- a/src/event.h
+++ b/src/event.h
@@ -1,0 +1,21 @@
+/* event.h - event sources */
+
+#ifndef EVENT_H
+#define EVENT_H
+
+struct event;
+
+extern struct event *event_fdread(int fd);
+extern struct event *event_routeup(void);
+extern struct event *event_suspend(void);
+extern struct event *event_every(int seconds);
+
+extern struct event *event_composite(void);
+extern int event_composite_add(struct event *comp, struct event *e);
+extern int event_composite_del(struct event *comp, struct event *e);
+
+extern int event_wait(struct event *e);
+
+extern void event_free(struct event *e);
+
+#endif /* !EVENT_H */

--- a/src/include.am
+++ b/src/include.am
@@ -183,6 +183,7 @@ src_tlsdated_SOURCES+= src/common/android.c
 endif
 
 src_tlsdated_SOURCES+= src/conf.c
+src_tlsdated_SOURCES+= src/event.c
 src_tlsdated_SOURCES+= src/routeup.c
 src_tlsdated_SOURCES+= src/tlsdated.c
 src_tlsdated_SOURCES+= src/util.c
@@ -192,7 +193,8 @@ src_tlsdate_dbus_announce_LDADD = @DBUS_LIBS@
 src_tlsdate_dbus_announce_SOURCES = src/tlsdate-dbus-announce.c
 
 src_tlsdated_unittest_LDADD = @SSL_LIBS@
-src_tlsdated_unittest_SOURCES = src/routeup.c
+src_tlsdated_unittest_SOURCES = src/event.c
+src_tlsdated_unittest_SOURCES+= src/routeup.c
 src_tlsdated_unittest_SOURCES+= src/tlsdated-unittest.c
 src_tlsdated_unittest_SOURCES+= src/util.c
 src_tlsdated_unittest_SOURCES+= src/tlsdated.c
@@ -423,6 +425,12 @@ endif
 endif
 endif
 endif
+
+src_event_unittest_SOURCES = src/event.c
+src_event_unittest_SOURCES+= src/event-unittest.c
+src_event_unittest_SOURCES+= src/routeup.c
+src_event_unittest_SOURCES+= src/util.c
+check_PROGRAMS+= src/event_unittest
 
 if !TARGET_OSX
 check_PROGRAMS+= src/test/proxy-override src/test/return-argc \

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -11,6 +11,7 @@
 #define TLSDATE_H
 
 #include "src/configmake.h"
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,6 +85,9 @@ struct opts {
   int leap;
 };
 
+char timestamp_path[PATH_MAX];
+
+void sync_hwclock (void *rtc_handle);
 int is_sane_time (time_t ts);
 int load_disk_timestamp (const char *path, time_t * t);
 void save_disk_timestamp (const char *path, time_t t);

--- a/src/tlsdated-unittest.c
+++ b/src/tlsdated-unittest.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 FIXTURE(tempdir) {
@@ -195,6 +196,24 @@ TEST(proxy_override) {
   EXPECT_EQ(0, tlsdate(&opts, environ));
 }
 
+FIXTURE(mock_platform) {
+  struct platform platform;
+  struct platform *old_platform;
+};
+
+FIXTURE_SETUP(mock_platform) {
+  self->old_platform = platform;
+  self->platform.rtc_open = NULL;
+  self->platform.rtc_write = NULL;
+  self->platform.rtc_read = NULL;
+  self->platform.rtc_close = NULL;
+  platform = &self->platform;
+}
+
+FIXTURE_TEARDOWN(mock_platform) {
+  platform = self->old_platform;
+}
+
 TEST(tlsdate_args) {
   struct source s1 = {
     .next = NULL,
@@ -211,6 +230,67 @@ TEST(tlsdate_args) {
   opts.leap = 1;
   verbose = 1;
   EXPECT_EQ(9, tlsdate(&opts, environ));
+}
+
+/*
+ * The stuff below this line is ugly. For a lot of these mock functions, we want
+ * to smuggle some state (our success) back to the caller, but there's no angle
+ * for that, so we're basically stuck with some static variables to store
+ * expectations and successes/failures. This could also be done with nested
+ * functions, but only gcc supports them.
+ */
+static const time_t sync_hwclock_expected = 12345678;
+
+static int sync_hwclock_time_get(struct timeval *tv) {
+  tv->tv_sec = sync_hwclock_expected;
+  tv->tv_usec = 0;
+  return 0;
+}
+
+static int sync_hwclock_rtc_write(void *handle, const struct timeval *tv) {
+  *(int *)handle = tv->tv_sec == sync_hwclock_expected;
+  return 0;
+}
+
+TEST_F(mock_platform, sync_hwclock) {
+  int ok = 0;
+  void *fake_handle = (void *)&ok;
+  self->platform.time_get = sync_hwclock_time_get;
+  self->platform.rtc_write = sync_hwclock_rtc_write;
+  sync_hwclock(fake_handle);
+  ASSERT_EQ(ok, 1);
+}
+
+static const time_t sync_and_save_expected = 12345678;
+
+static int sync_and_save_time_get(struct timeval *tv) {
+  tv->tv_sec = sync_and_save_expected;
+  tv->tv_usec = 0;
+  return 0;
+}
+
+static int sync_and_save_rtc_write(void *handle, const struct timeval *tv) {
+  *(int *)handle += tv->tv_sec == sync_and_save_expected;
+  return 0;
+}
+
+static int sync_and_save_file_write_ok = 0;
+
+static int sync_and_save_file_write(const char *path, void *buf, size_t sz) {
+  if (!strcmp(path, timestamp_path))
+    sync_and_save_file_write_ok++;
+  return 0;
+}
+
+TEST_F(mock_platform, sync_and_save) {
+  int nosave_ok = 0;
+  self->platform.time_get = sync_and_save_time_get;
+  self->platform.rtc_write = sync_and_save_rtc_write;
+  self->platform.file_write = sync_and_save_file_write;
+  sync_and_save(&sync_and_save_file_write_ok, 1);
+  ASSERT_EQ(sync_and_save_file_write_ok, 2);
+  sync_and_save(&nosave_ok, 0);
+  ASSERT_EQ(nosave_ok, 1);
 }
 
 TEST_HARNESS_MAIN

--- a/src/util.h
+++ b/src/util.h
@@ -18,6 +18,8 @@
 
 #define API __attribute__((visibility("default")))
 
+extern const char *kTempSuffix;
+
 extern int verbose;
 void die (const char *fmt, ...);
 void verb (const char *fmt, ...);
@@ -40,5 +42,22 @@ void drop_privs_to (const char *user, const char *group);
 /* like wait(), but with a timeout. Returns ordinary fork() error codes, or
  * ETIMEDOUT. */
 pid_t wait_with_timeout(int *status, int timeout_secs);
+
+struct platform {
+	void *(*rtc_open)(void);
+	int (*rtc_write)(void *handle, const struct timeval *tv);
+	int (*rtc_read)(void *handle, struct timeval *tv);
+	int (*rtc_close)(void *handle);
+
+	int (*file_write)(const char *path, void *buf, size_t sz);
+	int (*file_read)(const char *path, void *buf, size_t sz);
+
+	int (*time_get)(struct timeval *tv);
+
+	int (*pgrp_enter)(void);
+	int (*pgrp_kill)(void);
+};
+
+extern struct platform *platform;
 
 #endif /* !UTIL_H */

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 kill_tlsdated() {
-	kill -9 $PPID
+	kill -TERM $PPID
 }
 
 passed() {


### PR DESCRIPTION
Refactor the event loop to be modular and testable. Also, add support for
detecting corruption of the realtime clock, as can be caused by suspend/resume
cycles without an rtc battery. The event loop is now driven by a tree of events,
which are either sources (currently suspend/resume events, periodic events, and
network route events) or composite events.

Signed-off-by: Elly Fong-Jones <elly@leptoquark.net.
