### PR TITLE
time() is declared in time.h not sys/time.h

### DIFF
--- a/src/event-unittest.c
+++ b/src/event-unittest.c
@@ -1,7 +1,7 @@
 #include "src/event.h"
 #include "src/test_harness.h"
 
-#include <sys/time.h>
+#include <time.h>
 
 TEST(every) {
 	struct event *e = event_every(3);


### PR DESCRIPTION
time() is declared in time.h not sys/time.h
