### PR TITLE
Check return state of write(), otherwise this fails for compilers for un...

### DIFF
--- a/src/event-unittest.c
+++ b/src/event-unittest.c
@@ -21,7 +21,7 @@ TEST(fdread) {
 	ASSERT_EQ(0, pipe(fds));
 	e = event_fdread(fds[0]);
 
-	write(fds[1], &z, 1);
+	EXPECT_EQ(1, write(fds[1], &z, 1));
 	EXPECT_EQ(1, event_wait(e));
 	event_free(e);
 }


### PR DESCRIPTION
If you have the unused flag set and you don't check the return value of write() the compiler will complain at you.
