### PR TITLE
tlsdate-helper: abort if time delay is too large.

### DIFF
--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1385,6 +1385,10 @@ main(int argc, char **argv)
   rt_time_ms);
 
   /* warning if the handshake took too long */
+  if (rt_time_ms > TLS_RTT_UNREASONABLE) {
+    die ("the TLS handshake took more than %d msecs - consider using a different " \
+      "server or run it again\n", TLS_RTT_UNREASONABLE);
+  }
   if (rt_time_ms > TLS_RTT_THRESHOLD) {
     verb ("V: the TLS handshake took more than %d msecs - consider using a different " \
       "server or run it again\n", TLS_RTT_THRESHOLD);

--- a/src/tlsdate-helper.h
+++ b/src/tlsdate-helper.h
@@ -80,6 +80,10 @@ int verbose_debug;
 // (in msec), a warning is printed.
 #define TLS_RTT_THRESHOLD      2000
 
+// After the duration of the TLS handshake exceeds this threshold
+// (in msec), we consider the operation to have failed.
+#define TLS_RTT_UNREASONABLE      30000
+
 // RFC 5280 says...
 // ub-common-name-length INTEGER ::= 64
 #define MAX_CN_NAME_LENGTH 64


### PR DESCRIPTION
Such a large timeout could indicate tampering, but at the very least,
it means we didn't set the time accurately.  So exit with an error code and
let the caller try again later.
