### PR TITLE
Fix configure and build errors on OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -461,14 +461,6 @@ AC_DEFINE_UNQUOTED([DBUS_CLIENT_GROUP], ["${DBUS_CLIENT_GROUP}"], [DBus client g
 AC_MSG_RESULT(${DBUS_CLIENT_GROUP})
 AC_SUBST([DBUS_CLIENT_GROUP])
 
-dnl Check for clock_gettime.  Some systems put it into -lc, while
-dnl others use -lrt.  Try the first and fallback to the latter.
-RT_LIB=
-AC_CHECK_FUNC([clock_gettime], [:],
-              [AC_CHECK_LIB([rt], [clock_gettime], [RT_LIB="-lrt"],
-                            [AC_MSG_ERROR([Your system lacks clock_gettime])])])
-AC_SUBST(RT_LIB)
-
 PKG_CHECK_MODULES([LIBEVENT], [libevent >= 2.0])
 
 have_dbus=false

--- a/src/util.c
+++ b/src/util.c
@@ -286,12 +286,7 @@ int rtc_close(struct rtc_handle *handle)
 
 int file_write(int fd, void *buf, size_t sz)
 {
-	struct iovec iov[1];
-	ssize_t ret;
-	iov[0].iov_base = buf;
-	iov[0].iov_len = sz;
-	ret = IGNORE_EINTR (pwritev (fd, iov, 1, 0));
-	if (ret != sz)
+	if (IGNORE_EINTR(pwrite(fd, buf, sz, 0)) != sz)
 	{
 		return -1;
 	}
@@ -329,10 +324,7 @@ int file_close(int fd)
 
 int file_read(int fd, void *buf, size_t sz)
 {
-	struct iovec iov[1];
-	iov[0].iov_base = buf;
-	iov[0].iov_len = sz;
-	if (preadv (fd, iov, 1, 0) != sz)
+	if (pread(fd, buf, sz, 0) != sz)
 	{
 		/* Returns -1 on read failure */
 		return -1;


### PR DESCRIPTION
Hi,

On OS X 10.10 I can only find `readv` and `writev` but not `preadv` or `pwritev`, so I substituted `preadv` with `lseek`+`readv` if `preadv` is not available, and did the same for `pwritev`.
I also removed a seemingly redundant autoconf check for `clock_gettime`, which broke the OS X configuration. The same check already exists in the case statements for platforms, which need `clock_gettime`.

I tested my changes on OS X 10.10 (Yosemite) and Debian Wheezy (`make check` tests passed).
I hope I did not break the build on any other platform.

If there is a better way to fix the build errors on OS X, please comment and I will update the PR.
Thanks.

Regards,
Clemens
