### PR TITLE
add install section to systemd service file

### DIFF
--- a/systemd/tlsdated.service
+++ b/systemd/tlsdated.service
@@ -8,3 +8,6 @@ EnvironmentFile=/etc/default/tlsdated
 ExecStart=/usr/sbin/tlsdated ${DAEMON_OPTS}
 ExecReload=/bin/kill -HUP ${MAINPID}
 ExecStop=/bin/kill -INT ${MAINPID}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
install section as used by Gentoo [1], Arch [2], and Fedora [3] was added to the systemd service file

[1] https://bugs.gentoo.org/show_bug.cgi?id=533380
[2] https://aur.archlinux.org/packages/tlsdate/
[3] https://bugzilla.redhat.com/show_bug.cgi?id=969723
