### PR TITLE
Tighten code validations

### DIFF
--- a/src/proxy-bio-plan9.c
+++ b/src/proxy-bio-plan9.c
@@ -439,7 +439,7 @@ int API BIO_proxy_set_host(BIO *b, const char *host)
   if (strlen(host) == NI_MAXHOST)
     return 1;
   ctx->host = strdup(host);
-  return 0;
+  return NULL == ctx->host;
 }
 
 void API BIO_proxy_set_port(BIO *b, uint16_t port)

--- a/src/proxy-bio.c
+++ b/src/proxy-bio.c
@@ -420,7 +420,7 @@ int API BIO_proxy_set_host (BIO *b, const char *host)
   if (strnlen (host, NI_MAXHOST) == NI_MAXHOST)
     return 1;
   ctx->host = strdup (host);
-  return 0;
+  return NULL == ctx->host;
 }
 
 void API BIO_proxy_set_port (BIO *b, uint16_t port)

--- a/src/proxy-polarssl.c
+++ b/src/proxy-polarssl.c
@@ -314,7 +314,7 @@ int API proxy_polarssl_set_host(proxy_polarssl_ctx *ctx, const char *host)
   if (strnlen(host, NI_MAXHOST) == NI_MAXHOST)
     return 1;
   ctx->host = strdup(host);
-  return 0;
+  return NULL == ctx->host;
 }
 
 void API proxy_polarssl_set_port(proxy_polarssl_ctx *ctx, uint16_t port)

--- a/src/test-bio.c
+++ b/src/test-bio.c
@@ -49,6 +49,8 @@ static size_t buf_drain (unsigned char **buf, size_t *bufsz,
     memmove (*buf, *buf + outsz, *bufsz - outsz);
   *bufsz -= outsz;
   *buf = realloc (*buf, *bufsz);
+  if (*buf == NULL)
+    fatal("out of memory for buf");
   return outsz;
 }
 
@@ -56,6 +58,8 @@ static void buf_fill (unsigned char **buf, size_t *bufsz,
                       const unsigned char *in, size_t insz)
 {
   *buf = realloc (*buf, *bufsz + insz);
+  if (*buf == NULL)
+    fatal("out of memory for buf");
   memcpy (*buf + *bufsz, in, insz);
   *bufsz += insz;
 }

--- a/src/tlsdate-helper-plan9.c
+++ b/src/tlsdate-helper-plan9.c
@@ -114,6 +114,8 @@ validate_proxy_host(const char *host)
                        "abcdefghijklmnopqrstuvwxyz"
                        "0123456789"
                        ".-";
+  if (!*host)
+    die("host is empty\n");
   if (strspn(host, kValid) != strlen(host))
     die("invalid char in host\n");
 }
@@ -121,6 +123,8 @@ validate_proxy_host(const char *host)
 static void
 validate_proxy_port(const char *port)
 {
+  if (!*port)
+    die("port is empty\n");
   while (*port)
     if (!isdigit(*port++))
       die("invalid char in port\n");

--- a/src/tlsdate-helper-plan9.c
+++ b/src/tlsdate-helper-plan9.c
@@ -324,6 +324,8 @@ dns_label_count(char *label, char *delim)
   uint32_t label_count;
 
   label_tmp = strdup(label);
+  if (NULL == label_tmp)
+    fatal("out of memory for label_tmp");
   label_count = 0;
   saveptr = NULL;
   saveptr_tmp = NULL;
@@ -371,11 +373,15 @@ check_wildcard_match_rfc2595 (const char *orig_hostname,
 
   // First we copy the original strings
   hostname = strdup(orig_hostname);
+  if (NULL == hostname)
+    fatal("out of memory for hostname");
   cert_wild_card = strdup(orig_cert_wild_card);
+  if (NULL == cert_wild_card)
+    fatal("out of memory for cert_wild_card");
   hostname_to_free = hostname;
   cert_wild_card_to_free = cert_wild_card;
-  delim = strdup(".");
-  wildchar = strdup("*");
+  delim = ".";
+  wildchar = "*";
 
   verb ("V: Inspecting '%s' for possible wildcard match against '%s'\n",
          hostname, cert_wild_card);
@@ -444,8 +450,6 @@ check_wildcard_match_rfc2595 (const char *orig_hostname,
     ok = 0;
   }
   // Free our copies
-  free(wildchar);
-  free(delim);
   free(hostname_to_free);
   free(cert_wild_card_to_free);
   if (wildcard_encountered & ok && label_count >= RFC2595_MIN_LABEL_COUNT)

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -115,6 +115,8 @@ validate_proxy_host(const char *host)
                        "abcdefghijklmnopqrstuvwxyz"
                        "0123456789"
                        ".-";
+  if (!*host)
+    die("host is invalid");
   if (strspn(host, kValid) != strlen(host))
     die("invalid char in host");
 }
@@ -122,6 +124,8 @@ validate_proxy_host(const char *host)
 static void
 validate_proxy_port(const char *port)
 {
+  if (!*port)
+    die("port is empty");
   while (*port)
     if (!isdigit((int)(unsigned char)*port++))
       die("invalid char in port");

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -472,6 +472,8 @@ dns_label_count(char *label, char *delim)
   uint32_t label_count;
 
   label_tmp = strdup(label);
+  if (NULL == label_tmp)
+    fatal("out of memory for label_tmp");
   label_count = 0;
   saveptr = NULL;
   saveptr_tmp = NULL;
@@ -518,11 +520,15 @@ check_wildcard_match_rfc2595 (const char *orig_hostname,
 
   // First we copy the original strings
   hostname = strndup(orig_hostname, strlen(orig_hostname));
+  if (NULL == hostname)
+    fatal("out of memory for hostname");
   cert_wild_card = strndup(orig_cert_wild_card, strlen(orig_cert_wild_card));
+  if (NULL == cert_wild_card)
+    fatal("out of memory for cert_wild_card");
   hostname_to_free = hostname;
   cert_wild_card_to_free = cert_wild_card;
-  delim = strdup(".");
-  wildchar = strdup("*");
+  delim = ".";
+  wildchar = "*";
 
   verb_debug ("V: Inspecting '%s' for possible wildcard match against '%s'",
          hostname, cert_wild_card);
@@ -591,8 +597,6 @@ check_wildcard_match_rfc2595 (const char *orig_hostname,
     ok = 0;
   }
   // Free our copies
-  free(wildchar);
-  free(delim);
   free(hostname_to_free);
   free(cert_wild_card_to_free);
   if (wildcard_encountered & ok && label_count >= RFC2595_MIN_LABEL_COUNT)


### PR DESCRIPTION
Check memory allocations and consider empty hosts/ports as invalid.
