### PR TITLE
Add rlimit and prevent the process from forking

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.0.14 XXX
+  Use prlimit on Linux to prevent tlsdate SSL code from forking again
 0.0.13 Thu 28, May, 2015
   Update default host to google.com - www.ptb.de randomized timestamps
 0.0.12 Sun 26, Oct, 2014

--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,8 @@ AM_CONDITIONAL(HAVE_STRCHRNUL, [test "x${ac_cv_func_strchrnul}" = xyes])
 AC_CHECK_FUNCS([strnlen])
 AM_CONDITIONAL(HAVE_STRNLEN, [test "x${ac_cv_func_strnlen}" = xyes])
 
+AC_CHECK_FUNCS([prlimit])
+
 AC_CHECK_FUNCS_ONCE(m4_flatten([
     gettimeofday
     prctl

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1353,6 +1353,7 @@ main(int argc, char **argv)
   if (0 == ssl_child)
   {
     drop_privs_to (UNPRIV_USER, UNPRIV_GROUP);
+    forbid_fork ();
     run_ssl (time_map, leap, http);
     (void) munmap (time_map, sizeof (uint32_t));
     _exit (0);

--- a/src/util.c
+++ b/src/util.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -146,6 +147,26 @@ void enable_seccomp(void)
   }
 #else
   verb ("V: seccomp support is disabled");
+#endif
+}
+
+/** Use prlimit to prevent a process from forking, thus making exploitation harder */
+void forbid_fork(void)
+{
+#ifdef TARGET_OS_LINUX
+#ifdef HAVE_PRLIMIT
+  const struct rlimit limit = {
+    .rlim_cur = 0,
+    .rlim_max = 0,
+  };
+
+  if (-1 == prlimit(0, RLIMIT_NPROC, &limit, NULL))
+  {
+    die ("Failed to prlimit: %s\n", strerror (errno));
+  }
+#else
+  verb ("V: prlimit is not supported");
+#endif
 #endif
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -65,6 +65,7 @@ static inline int min (int x, int y)
 
 void drop_privs_to (const char *user, const char *group);
 void no_new_privs (void);
+void forbid_fork (void);
 const char *sync_type_str (int sync_type);
 
 struct state;


### PR DESCRIPTION
While it doesn't prevent all exploitations, it make
like harder for a attacker who would want to spawn a shell
or similar type of attack.
