### PR TITLE
Enable few more architectures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.0.14
+  Add support for AArch64 and s/390(x) architectures.
 0.0.13 Thu 28, May, 2015
   Update default host to google.com - www.ptb.de randomized timestamps
 0.0.12 Sun 26, Oct, 2014

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -56,6 +56,10 @@
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64LE
 #elif defined(__powerpc64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
+#elif defined(__s390__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_S390
+#elif defined(__s390x__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_S390X
 #else
 #  error "Platform does not support seccomp filter yet"
 #endif

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -50,6 +50,12 @@
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARM
 #elif defined(__aarch64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_AARCH64
+#elif defined(__powerpc__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC
+#elif defined(__powerpc64le__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64LE
+#elif defined(__powerpc64__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
 #else
 #  error "Platform does not support seccomp filter yet"
 #endif

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -87,7 +87,9 @@ enable_setter_seccomp (void)
     SC_ALLOW (exit_group),
     SC_ALLOW (exit),
 
+#ifdef __NR_open
     SC_DENY (open, EINVAL),
+#endif
     SC_DENY (fcntl, EINVAL),
     SC_DENY (fstat, EINVAL),
 #ifdef __NR_mmap

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -48,6 +48,8 @@
 #   define EM_ARM 40
 # endif
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARM
+#elif defined(__aarch64__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_AARCH64
 #else
 #  error "Platform does not support seccomp filter yet"
 #endif


### PR DESCRIPTION
To get tlsdate built in Fedora we need support for all secondary architectures (AArch64, POWER, s/390).

Additionally had to mark open() system call as optional as it is deprecated one so does not exists on AArch64. openat() should be used instead.
