### PR TITLE
Enable TLS Server Name Indication

### DIFF
--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1152,7 +1152,7 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion, int http)
   {
     if (-1 == stat(ca_cert_container, &statbuf))
     {
-      die("Unable to stat CA certficate container %s", ca_cert_container);
+      die("Unable to stat CA certificate container %s", ca_cert_container);
     } else
     {
       switch (statbuf.st_mode & S_IFMT)

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1187,6 +1187,7 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion, int http)
   }
 
   SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
+  SSL_set_tlsext_host_name(ssl, host);
   verb("V: opening socket to %s:%s", host, port);
   if ( (1 != BIO_set_conn_hostname(s_bio, host)) ||
        (1 != BIO_set_conn_port(s_bio, port)) )


### PR DESCRIPTION
This enables TLS SNI.  See also: bug #161 and crbug.com/400429
