### PR TITLE
Add support for newer TLS versions (ignore this one)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.0.13 Thu 28, May, 2015
+  Update default host to google.com - www.ptb.de randomized timestamps
 0.0.12 Sun 26, Oct, 2014
   Fix AppArmor for tlsdated: allow unprivileged helper to read the time.
   Update tlsdated systemd service file.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([tlsdate],[0.0.12],[jacob at appelbaum.net])
+AC_INIT([tlsdate],[0.0.13],[jacob at appelbaum.net])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/src/tlsdate-helper-plan9.c
+++ b/src/tlsdate-helper-plan9.c
@@ -986,6 +986,14 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion)
   {
     verb ("V: using TLSv1_client_method()\n");
     ctx = SSL_CTX_new(TLSv1_client_method());
+  } else if (0 == strcmp("tlsv11", protocol))
+  {
+    verb ("V: using TLSv1_1_client_method()");
+    ctx = SSL_CTX_new(TLSv1_1_client_method());
+  } else if (0 == strcmp("tlsv12", protocol))
+  {
+    verb ("V: using TLSv1_2_client_method()");
+    ctx = SSL_CTX_new(TLSv1_2_client_method());
   } else
     die("Unsupported protocol `%s'\n", protocol);
 

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1141,6 +1141,14 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion, int http)
   {
     verb ("V: using TLSv1_client_method()");
     ctx = SSL_CTX_new(TLSv1_client_method());
+  } else if (0 == strcmp("tlsv11", protocol))
+  {
+    verb ("V: using TLSv1_1_client_method()");
+    ctx = SSL_CTX_new(TLSv1_1_client_method());
+  } else if (0 == strcmp("tlsv12", protocol))
+  {
+    verb ("V: using TLSv1_2_client_method()");
+    ctx = SSL_CTX_new(TLSv1_2_client_method());
   } else
     die("Unsupported protocol `%s'", protocol);
 

--- a/src/tlsdate.c
+++ b/src/tlsdate.c
@@ -88,7 +88,7 @@ usage (void)
            " [-n|--dont-set-clock]\n"
            " [-H|--host] [hostname|ip]\n"
            " [-p|--port] [port number]\n"
-           " [-P|--protocol] [sslv23|sslv3|tlsv1]\n"
+           " [-P|--protocol] [sslv23|sslv3|tlsv1|tlsv11|tlsv12]\n"
            " [-C|--certcontainer] [dirname|filename]\n"
            " [-v|--verbose]\n"
            " [-V|--showtime] [human|raw]\n"


### PR DESCRIPTION
I've just added a few lines to allow selection of the TLS1.1 and TLS1.2 CTX methods, and updated the --help.