### PR TITLE
Add support for TLSv1.1 and TLSv1.2

### DIFF
--- a/src/tlsdate-helper-plan9.c
+++ b/src/tlsdate-helper-plan9.c
@@ -986,6 +986,14 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion)
   {
     verb ("V: using TLSv1_client_method()\n");
     ctx = SSL_CTX_new(TLSv1_client_method());
+  } else if (0 == strcmp("tlsv11", protocol))
+  {
+    verb ("V: using TLSv1_1_client_method()");
+    ctx = SSL_CTX_new(TLSv1_1_client_method());
+  } else if (0 == strcmp("tlsv12", protocol))
+  {
+    verb ("V: using TLSv1_2_client_method()");
+    ctx = SSL_CTX_new(TLSv1_2_client_method());
   } else
     die("Unsupported protocol `%s'\n", protocol);
 

--- a/src/tlsdate-helper.c
+++ b/src/tlsdate-helper.c
@@ -1141,6 +1141,14 @@ run_ssl (uint32_t *time_map, int time_is_an_illusion, int http)
   {
     verb ("V: using TLSv1_client_method()");
     ctx = SSL_CTX_new(TLSv1_client_method());
+  } else if (0 == strcmp("tlsv11", protocol))
+  {
+    verb ("V: using TLSv1_1_client_method()");
+    ctx = SSL_CTX_new(TLSv1_1_client_method());
+  } else if (0 == strcmp("tlsv12", protocol))
+  {
+    verb ("V: using TLSv1_2_client_method()");
+    ctx = SSL_CTX_new(TLSv1_2_client_method());
   } else
     die("Unsupported protocol `%s'", protocol);
 

--- a/src/tlsdate.c
+++ b/src/tlsdate.c
@@ -88,7 +88,7 @@ usage (void)
            " [-n|--dont-set-clock]\n"
            " [-H|--host] [hostname|ip]\n"
            " [-p|--port] [port number]\n"
-           " [-P|--protocol] [sslv23|sslv3|tlsv1]\n"
+           " [-P|--protocol] [sslv23|sslv3|tlsv1|tlsv11|tlsv12]\n"
            " [-C|--certcontainer] [dirname|filename]\n"
            " [-v|--verbose]\n"
            " [-V|--showtime] [human|raw]\n"


### PR DESCRIPTION
I've just added a few lines to allow selection of the TLS1.1 and TLS1.2 CTX methods, and updated the --help.